### PR TITLE
:bug: snow not detected from subdirectory

### DIFF
--- a/test/3.repo.open.ts
+++ b/test/3.repo.open.ts
@@ -34,12 +34,41 @@ test('repo open-commondir-outside', async (t) => {
   const commondir = createRepoPath();
 
   let repo: Repository;
+  t.log(`Initialize repo at ${repoPath}`);
   await Repository.initExt(repoPath, { commondir });
 
   await Repository.open(repoPath)
     .then((repoResult: Repository) => {
       repo = repoResult;
+      t.log(`Opened repo at ${repo.workdir()}`);
+      t.log(`Found commondir at ${repo.commondir()}`);
       return testRepoCommondirOutside(t, repo);
+    })
+    .then(() => // cleanup unit-test
+      rmDirRecursive(repo.workdir()))
+    .then((): Promise<void> => // cleanup unit-test
+      rmDirRecursive(repo.commondir()));
+});
+
+test('repo open-commondir-outside-subdirectory', async (t) => {
+  /* Create a repository with a subdirectory and open the repo from the subdirectory.
+  The test ensures that Repository.open travels up the hierarchy to find the next .snow repo */
+  const repoPath = createRepoPath();
+  const commondir = createRepoPath();
+
+  let repo: Repository;
+  t.log(`Initialize repo at ${repoPath}`);
+  await Repository.initExt(repoPath, { commondir });
+
+  // create directory and open the repo from the sub-directory
+  const fooDir = join(repoPath, 'foo');
+  fse.mkdirpSync(fooDir);
+  await Repository.open(fooDir)
+    .then((repoResult: Repository) => {
+      repo = repoResult;
+      t.log(`Opened repo at ${repo.workdir()}`);
+      t.log(`Found commondir at ${repo.commondir()}`);
+      t.is(repoResult.workdir(), repoPath, 'expect repository being opened from subdirectory');
     })
     .then(() => // cleanup unit-test
       rmDirRecursive(repo.workdir()))
@@ -51,12 +80,40 @@ test('repo open-commondir-inside', async (t) => {
   const repoPath = createRepoPath();
 
   let repo: Repository;
+  t.log(`Initialize repo at ${repoPath}`);
   await Repository.initExt(repoPath);
 
   await Repository.open(repoPath)
     .then((repoResult: Repository) => {
       repo = repoResult;
+      t.log(`Opened repo at ${repo.workdir()}`);
+      t.log(`Found commondir at ${repo.commondir()}`);
       return testRepoCommondirInside(t, repo);
+    })
+    .then(() => // cleanup unit-test
+      rmDirRecursive(repo.workdir()))
+    .then((): Promise<void> => // cleanup unit-test
+      rmDirRecursive(repo.commondir()));
+});
+
+test('repo open-commondir-inside-subdirectory', async (t) => {
+  /* Create a repository with a subdirectory and open the repo from the subdirectory.
+  The test ensures that Repository.open travels up the hierarchy to find the next .snow repo */
+  const repoPath = createRepoPath();
+
+  let repo: Repository;
+  t.log(`Initialize repo at ${repoPath}`);
+  await Repository.initExt(repoPath);
+
+  // create directory and open the repo from the sub-directory
+  const fooDir = join(repoPath, 'foo');
+  fse.mkdirpSync(fooDir);
+  await Repository.open(fooDir)
+    .then((repoResult: Repository) => {
+      repo = repoResult;
+      t.log(`Opened repo at ${repo.workdir()}`);
+      t.log(`Found commondir at ${repo.commondir()}`);
+      t.is(repoResult.workdir(), repoPath, 'expect repository being opened from subdirectory');
     })
     .then(() => // cleanup unit-test
       rmDirRecursive(repo.workdir()))


### PR DESCRIPTION
Add support for `Repository.open` opening a sub-directory and still finding the repo

Fixes #4

- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)