### PR TITLE
:penguin: Add support for different node executable locations

### DIFF
--- a/bin/snow
+++ b/bin/snow
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+node_executable=`which node`
+if [ ! -e $node_executable ]; then
+    echo "node not found, you must install nodejs runtime"
+    exit 1
+fi
+
 script_directory=`dirname $0`
 if [ ! -d $script_directory/../node_modules/ ]; then
     echo "node_modules missing - you must first install all node packages by executing 'npm install' in the root directory of SnowFS"
@@ -11,4 +17,4 @@ if [[ -z "${SUPPRESS_BANNER}" ]]; then
     echo "                For production build visit https://github.com/Snowtrack/SnowFS/releases"
 fi
 
-/usr/local/bin/node -r $0/../../node_modules/ts-node/register $0/../../main.ts "$@"
+$node_executable -r $0/../../node_modules/ts-node/register $0/../../main.ts "$@"


### PR DESCRIPTION
Stop using hard coded /usr/local/bin/node.
Prevent crashes when node is at other locations, like /usr/bin/node.

It wouldn't run for me on my Linux machine where node is located at /usr/bin/node
Now, wherever it finds node in PATH first it will use that. I'm not totally sure if there is some specific convention for when a user wants to supply their own version of node, but this will at least fix a lot of cases on Linux.

## Checks

- [ ] I added my name to the contributor list in **CONTRIBUTORS.md**
- [x] I understand that my work will be licensed under the given license of `SnowFS`
- [x] I am the original author, or I have authorization to submit this work.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)