### PR TITLE
:star: Add support for tags to commits

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -304,7 +304,7 @@ program
       let data = {};
 
       let tags: string[];
-      if (opts.tags.length > 0) {
+      if (opts.tags && opts.tags.length > 0) {
         tags = String(opts.tags).split(',');
       }
 

--- a/main.ts
+++ b/main.ts
@@ -295,12 +295,18 @@ program
   .option('--allow-empty', 'allow an empty commit without any changes, not set by default')
   .option('--debug', 'add more debug information on errors')
   .option('--user-data', 'open standard input to apply user data for commit')
+  .option('--tags [collection]', 'add user defined tags to commit')
   .description('complete the commit')
   .action(async (opts: any) => {
     try {
       const repo = await Repository.open(process.cwd());
       const index: Index = repo.getIndex();
       let data = {};
+
+      let tags: string[];
+      if (opts.tags.length > 0) {
+        tags = String(opts.tags).split(',');
+      }
 
       let res: string;
       if (opts.userData) {
@@ -313,7 +319,7 @@ program
         }
       }
 
-      const newCommit: Commit = await repo.createCommit(index, opts.message, opts, data);
+      const newCommit: Commit = await repo.createCommit(index, opts.message, opts, tags, data);
 
       console.log(`[${repo.getHead().getName()} (root-commit) ${newCommit.hash.substr(0, 6)}]`);
     } catch (error) {
@@ -369,6 +375,7 @@ program
               message: value.message,
               date: value.date.getTime() / 1000.0,
               root: opts.verbose ? value.root : undefined,
+              tags: value.tags,
               userData: JSON.parse(JSON.stringify(value.userData)),
             };
           }
@@ -420,6 +427,16 @@ program
           process.stdout.write('\n');
 
           process.stdout.write(`Date: ${commit.date}\n`);
+
+          if (commit.tags && commit.tags.length > 0) {
+            process.stdout.write('Tags:');
+            let seperator = ' ';
+            commit.tags.forEach((tag) => {
+              process.stdout.write(`${seperator}${tag}`);
+              seperator = ', ';
+            });
+            process.stdout.write('\n');
+          }
 
           if (Object.keys(commit.userData).length > 0) {
             process.stdout.write('User Data:');

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -14,6 +14,8 @@ export class Commit {
   /** Unique commit hash */
   hash: string;
 
+  tags: string[];
+
   /** Custom commit user data, that was added to [[Repository.createCommit]]. */
   userData: any;
 
@@ -34,6 +36,7 @@ export class Commit {
 
   constructor(repo: Repository, message: string, creationDate: Date, root: TreeDir, parent: string[] | null) {
     this.hash = crypto.createHash('sha256').update(process.hrtime().toString()).digest('hex');
+    this.tags = [];
     this.userData = {};
     this.repo = repo;
     this.message = message;
@@ -52,11 +55,16 @@ export class Commit {
       this.root,
       this.parent ? [...this.parent] : []);
     commit.hash = this.hash;
-    commit.userData = { ...this.userData };
-    // // eslint-disable-next-line guard-for-in
-    // for (const key in this.userData) {
-    //   commit.userData[key] = this.userData[key];
-    // }
+
+    commit.tags = [];
+    if (this.tags != null) {
+      commit.tags = [...this.tags];
+    }
+
+    commit.userData = {};
+    if (this.userData != null) {
+      commit.userData = { ...this.userData };
+    }
 
     return commit;
   }
@@ -66,6 +74,35 @@ export class Commit {
    */
   addData(key: string, value: any) {
     this.userData[key] = value;
+  }
+
+  /**
+   * Add custom tag to the commit object.
+   */
+  addTag(tag: string) {
+    if (tag.length === 0) {
+      return;
+    }
+
+    if (this.tags == null) {
+      this.tags = [];
+    }
+
+    if (this.tags.includes(tag)) {
+      return;
+    }
+
+    tag = tag
+      .replace(/\\n/g, '\\n')
+      .replace(/\\'/g, "\\'")
+      .replace(/\\"/g, '\\"')
+      .replace(/\\&/g, '\\&')
+      .replace(/\\r/g, '\\r')
+      .replace(/\\t/g, '\\t')
+      .replace(/\\b/g, '\\b')
+      .replace(/\\f/g, '\\f');
+
+    this.tags.push(tag);
   }
 
   /**

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -92,6 +92,7 @@ export class Commit {
       return;
     }
 
+    // replace JSON invalid symbols
     tag = tag
       .replace(/\\n/g, '\\n')
       .replace(/\\'/g, "\\'")

--- a/src/odb.ts
+++ b/src/odb.ts
@@ -201,6 +201,15 @@ export class Odb {
                   "date": ${commit.date.getTime()},
                   "parent": [${parent}], "root":`);
     stream.write(commit.root.toString(true));
+    if (commit.tags) {
+      stream.write(',"tags": [');
+      let seperator = ' ';
+      commit.tags.forEach((tag) => {
+        stream.write(`${seperator}"${tag}"`);
+        seperator = ', ';
+      });
+      stream.write(' ]');
+    }
     if (commit.userData) {
       stream.write(`,"userData": ${JSON.stringify(commit.userData)}`);
     }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -695,7 +695,7 @@ export class Repository {
    * @param userData Custom data that is attached to the commit data. The data must be JSON.stringifyable.
    * @returns     New commit object.
    */
-  async createCommit(index: Index, message: string, opts?: {allowEmpty?: boolean}, userData?: {}): Promise<Commit> {
+  async createCommit(index: Index, message: string, opts?: {allowEmpty?: boolean}, tags?: string[], userData?: {}): Promise<Commit> {
     let tree: TreeDir;
     let commit: Commit;
     if (index.adds.size === 0 && index.deletes.size === 0 && (!opts || !opts.allowEmpty)) {
@@ -714,6 +714,13 @@ export class Repository {
         return index.reset();
       }).then(() => {
         commit = new Commit(this, message, new Date(), tree, [this.head ? this.head.hash : null]);
+
+        if (tags && tags.length > 0) {
+          tags.forEach((tag: string) => {
+            commit.addTag(tag);
+          });
+        }
+
         if (userData) {
           for (const [key, value] of Object.entries(userData)) {
             commit.addData(key, value);

--- a/test/4.repo.commit.ts
+++ b/test/4.repo.commit.ts
@@ -216,7 +216,7 @@ test('custom-commit-data', async (t) => {
     return index.writeFiles();
   }).then(() => {
     const index = repo.getIndex();
-    return repo.createCommit(index, 'This is a commit with custom-data', {}, { hello: 'world', foo: 'bar', bas: 3 });
+    return repo.createCommit(index, 'This is a commit with custom-data', {}, [], { hello: 'world', foo: 'bar', bas: 3 });
   })
     .then((commit: Commit) => {
       t.log('User Data of commit', commit.userData);


### PR DESCRIPTION
The ability to add **tags** to commits makes it easier to semantically filter for specific changes within a repository.
Tags can be added via the commandline when committing, e.g.:

`cwd>snow commit -m "Move Player Spawn Point to avoid Obstacle" --tags=mountain-level,layout-three,pirates`

Tags can be read via the json file received from the log command.

```
{
  "hash": "c586098a16d877e0caf649239800fc0b1f6632f5b3113a5b484b05caf11504fd",
  "message": "Move Player Spawn Point to avoid Obstacle",
  "date": 1614300177.598,
  "tags": [
    "mountain-level",
    "layout-three",
    "pirates"
  ],
  "userData": {}
}
```
Closes #37 