### PR TITLE
:star: Add support for user data in refs

### DIFF
--- a/src/odb.ts
+++ b/src/odb.ts
@@ -137,6 +137,7 @@ export class Odb {
         const opts = {
           hash: ret.content.hash,
           start: ret.content.start,
+          userData: ret.content.userData,
         };
         return new Reference(basename(ret.ref.path), this.repo, opts);
       }))
@@ -185,6 +186,7 @@ export class Odb {
     return fse.writeFile(refPath, JSON.stringify({
       hash: ref.hash,
       start: ref.start ? ref.start : undefined,
+      userData: ref.userData ?? {},
     }));
   }
 

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -7,14 +7,18 @@ import { Repository } from './repository';
 export class Reference {
     hash: string;
 
+    /** Custom commit user data, that was added to [[Repository.createCommit]]. */
+    userData: any;
+
     refName: string;
 
     repo: Repository;
 
     start: string;
 
-    constructor(refName: string, repo: Repository, c: {hash: string, start: string}) {
+    constructor(refName: string, repo: Repository, c: {hash: string, start: string, userData?: any}) {
       this.hash = c.hash;
+      this.userData = c.userData ?? {};
       this.start = c.start;
       this.refName = refName;
       this.repo = repo;
@@ -41,6 +45,17 @@ export class Reference {
     }
 
     clone(): Reference {
-      return new Reference(this.refName, this.repo, { hash: this.hash, start: this.start });
+      const ref = new Reference(this.refName, this.repo,
+        {
+          hash: this.hash,
+          start: this.start,
+        });
+
+      ref.userData = {};
+      if (this.userData != null) {
+        ref.userData = { ...this.userData };
+      }
+
+      return ref;
     }
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -401,7 +401,7 @@ export class Repository {
    * @param hash  Commit hash of the new reference.
    * @param start Set commit hash of the start of the reference.
    */
-  async createNewReference(name: string, hash: string, start?: string|null): Promise<Reference> {
+  async createNewReference(name: string, hash: string, start?: string|null, userData?: {}): Promise<Reference> {
     const existingRef: Reference = this.references.find((ref: Reference) => ref.getName() === name);
     if (existingRef) {
       throw new Error('ref already exists');
@@ -415,7 +415,8 @@ export class Repository {
       throw new Error('hash for new ref is not a known commit');
     }
 
-    const newRef: Reference = new Reference(name, this, { hash, start: start ?? hash });
+    const newRef: Reference = new Reference(name, this, { hash, start: start ?? hash, userData });
+
     this.references.push(newRef);
     return this.repoOdb.writeReference(newRef).then(() => newRef);
   }


### PR DESCRIPTION
Add the option to write, store and read additional data for refs. This will allow flexible customization for end users.
When creating a new branch, user data can be added via the command 

`snow checkout -b branch-name --input=stdin`

and subsequently writing

`--user-data:{"color" : "#FF3245"}`

to the std input. This will resilt in a new branch with the following layout.

```
{
  "hash" : "96ad22c7b26f3042bc2fc7437dc704a7e7c2b53553cbf8d97f90a0ea498c14c2",
  "userData" : 
  {
    "color" : "#FF3245"
  }
}
```

(Closes #35)
