### PR TITLE
:bug: recycle-bin.exe / trash not found (Closes: 76)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import { difference } from 'lodash';
 
 import { isAbsolute, join, relative } from 'path';
 import { Commit } from './commit';
-import { putToTrash } from './common';
 import { IoContext } from './io_context';
 import { Odb } from './odb';
 import { Repository } from './repository';
@@ -153,7 +152,7 @@ export class Index {
           if (!filepathAbs.startsWith(this.repo.workdir())) {
             throw new Error(`file or directory not in workdir: ${filepath}`);
           }
-          promises.push(putToTrash(filepathAbs));
+          promises.push(IoContext.putToTrash(filepathAbs));
         }
         return promises;
       })

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -7,7 +7,7 @@ import {
 } from 'path';
 
 import { Commit } from './commit';
-import { properNormalize, putToTrash } from './common';
+import { properNormalize } from './common';
 import { IgnoreManager } from './ignore';
 import { Index } from './index';
 import { DirItem, OSWALK, osWalk } from './io';
@@ -537,7 +537,7 @@ export class Repository {
           // Delete files which didn't exist before, but do now
           const newFiles: string[] = difference(currentFiles, oldFilePaths);
           for (const newFile of newFiles) {
-            promises.push(putToTrash(join(this.repoWorkDir, newFile)));
+            promises.push(IoContext.putToTrash(join(this.repoWorkDir, newFile)));
           }
         }
 


### PR DESCRIPTION
Whenever SnowFS is embedded in another environment (e.g. Snowtrack), the files for `trash` or `recycle-bin.exe` might be located at a different location. To find them `IoContext.setTrashExecPath` should be called once on startup with a path to the given executable.