### PR TITLE
Add command to print driveinfo (Closes: #75)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -16,6 +16,7 @@ import { TreeDir, TreeFile } from './src/treedir';
 
 const program = require('commander');
 const chalk = require('chalk');
+const drivelist = require('drivelist');
 
 function fileMatch(relFilepath: string, relCwd: string, pathPattern: string): boolean {
   return pathPattern === '*' || (pathPattern === '.' && relFilepath.startsWith(relCwd)) || pathPattern === relative(relCwd, relFilepath);
@@ -556,6 +557,15 @@ program
         process.exit(-1);
       }
     }
+  });
+
+program
+  .command('driveinfo')
+  .option('--output [format=json-pretty]', "currently supported output formats 'json', 'json-pretty'")
+  .description('List all connected drives in your computer, in all major operating systems')
+  .action(async (opts: any) => {
+    const drives = await drivelist.list();
+    console.log(JSON.stringify(drives, null, opts.output === 'json' ? '' : '    '));
   });
 
 program.parse(process.argv.filter((x) => x !== '--'));

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -442,3 +442,27 @@ test('Branch User Data --- FAIL INVALID INPUT', async (t) => {
     t.true(error.message.includes(errorMsgSub));
   }
 });
+
+test('driveinfo test', async (t) => {
+  const snow: string = getSnowexec(t);
+
+  const out1 = await exec(t, snow, ['driveinfo'], {}, EXEC_OPTIONS.RETURN_STDOUT) as string;
+
+  const parsedObj = JSON.parse(out1);
+  if (!Array.isArray(parsedObj) || parsedObj.length === 0) {
+    t.fail('expected array with minimum size of 1 element');
+    return;
+  }
+
+  t.log(out1);
+  t.true(parsedObj[0].description?.length > 0, 'stdout must be a JSON parsable string');
+  t.true(out1.includes('    '), 'driveinfo uses --output json-pretty as default and requires a 4-width space JSON output');
+
+  const out2 = await exec(t, snow, ['driveinfo', '--output', 'json'], {}, EXEC_OPTIONS.RETURN_STDOUT) as string;
+  t.true(JSON.parse(out2).description?.length > 0, 'stdout must be a JSON parsable string');
+  t.true(out1.includes('    '), 'driveinfo --output json must return a minified JSON output');
+
+  const out3 = await exec(t, snow, ['driveinfo', '--output', 'json-pretty'], {}, EXEC_OPTIONS.RETURN_STDOUT) as string;
+  t.true(JSON.parse(out3).description?.length > 0, 'stdout must be a JSON parsable string');
+  t.true(out1.includes('    '), 'driveinfo --output json-pretty requires a 4-width space JSON output');
+});


### PR DESCRIPTION
This is a new feature:

```
$ snow driveinfo
```

The result is a stringified JSON representation of all mounted drives with an expected output like this:

```
[
    {
        "enumerator": "SCSI",
        "busType": "RAID",
        "busVersion": "2.0",
        "device": "\\\\.\\PhysicalDrive0",
        "devicePath": null,
        "raw": "\\\\.\\PhysicalDrive0",
        "description": "WDC PC SN530 SDBPNPZ-512G-1014",
        "partitionTableType": "gpt",
        "error": null,
        "size": 512110190592,
        "blockSize": 512,
        "logicalBlockSize": 512,
        "mountpoints": [
            {
                "path": "C:\\"
            }
        ],
        "isReadOnly": false,
        "isSystem": true,
        "isVirtual": false,
        "isRemovable": false,
        "isCard": false,
        "isSCSI": true,
        "isUSB": false,
        "isUAS": false
    }
]
```