### PR TITLE
:star: Add logging support

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,45 @@
+import * as fse from 'fs-extra';
+import { join } from 'path';
+import { Repository } from './repository';
+
+/**
+ * Return the timezone offset in the UTC designator Z notation.
+ * @param date      Instance of `Date`
+ * @returns         E.g. -0500
+ */
+function getZOffset(date: Date) {
+  function fill(value: number) {
+    return value < 10 ? `0${value}` : value;
+  }
+  const offset = Math.abs(date.getTimezoneOffset());
+  const hours = fill(Math.floor(offset / 60));
+  const minutes = fill(offset % 60);
+  const sign = (date.getTimezoneOffset() > 0) ? '-' : '+';
+  return `${sign + hours}${minutes}`;
+}
+
+/**
+ * The log helper class of a Repository
+ */
+export class Log {
+  // eslint-disable-next-line no-useless-constructor,no-empty-function
+  constructor(private repo: Repository) { }
+
+  getAbsLogDirPath(): string {
+    return join(this.repo.commondir(), 'logs');
+  }
+
+  async init() {
+    return fse.ensureDir(this.getAbsLogDirPath());
+  }
+
+  /**
+   * Writes a log message to .snow/logs/mainlog. The message is recommended to be a one-liner.
+   * @param message:          One-line message, e.g.  "commit: foo"
+   */
+  async writeLog(message: string) {
+    const now = new Date();
+    const logMessage = `${now.getTime()} ${getZOffset(now)} $> ${message}\n`;
+    return fse.appendFile(join(this.getAbsLogDirPath(), 'mainlog'), logMessage);
+  }
+}

--- a/test/2.repo.init.ts
+++ b/test/2.repo.init.ts
@@ -58,13 +58,14 @@ export async function testRepoCommondirOutside(t, repo: Repository) {
       return osWalk(repo.commondir(), OSWALK.DIRS | OSWALK.FILES | OSWALK.HIDDEN);
     })
     .then((dirItems: DirItem[]) => {
-      t.is(dirItems.length, 9, 'expected .snow reference with 9 elements inside');
+      t.is(dirItems.length, 11, 'expected .snow reference with 10 elements inside');
 
       t.true(fse.pathExistsSync(join(repo.commondir(), 'HEAD')), 'HEAD reference');
       t.true(fse.pathExistsSync(join(repo.commondir(), 'config')), 'repo must contain a config file');
       t.true(fse.pathExistsSync(join(repo.commondir(), 'hooks')), 'repo must contain a hooks directory');
       t.true(fse.pathExistsSync(join(repo.commondir(), 'objects')), 'repo must contain an objects directory');
       t.true(fse.pathExistsSync(join(repo.commondir(), 'refs')), 'repo must have a refs directory');
+      t.true(fse.pathExistsSync(join(repo.commondir(), 'logs', 'mainlog')), 'repo must contain a logs/mainlog file');
       t.true(fse.pathExistsSync(join(repo.commondir(), 'refs', 'Main')), 'Main reference');
       t.true(fse.pathExistsSync(join(repo.commondir(), 'indexes')), 'repo must contain an index directory');
       t.true(fse.pathExistsSync(join(repo.commondir(), 'versions')), 'repo must have a version directory');
@@ -85,12 +86,13 @@ export async function testRepoCommondirOutside(t, repo: Repository) {
 
 export async function testRepoCommondirInside(t, repo: Repository) {
   return osWalk(repo.workdir(), OSWALK.DIRS | OSWALK.FILES | OSWALK.HIDDEN).then((dirItems: DirItem[]) => {
-    t.is(dirItems.length, 9 + 1, 'expect .snow reference in workdir (+1 for .snow)');
+    t.is(dirItems.length, 11 + 1, 'expect .snow reference in workdir (+1 for .snow)');
 
     t.true(fse.pathExistsSync(join(repo.commondir(), 'HEAD')), 'HEAD reference');
     t.true(fse.pathExistsSync(join(repo.commondir(), 'config')), 'repo must contain a config file');
     t.true(fse.pathExistsSync(join(repo.commondir(), 'hooks')), 'repo must contain a hooks directory');
     t.true(fse.pathExistsSync(join(repo.commondir(), 'indexes')), 'repo must contain a index directory');
+    t.true(fse.pathExistsSync(join(repo.commondir(), 'logs', 'mainlog')), 'repo must contain a logs/mainlog file');
     t.true(fse.pathExistsSync(join(repo.commondir(), 'objects')), 'repo must contain an objects directory');
     t.true(fse.pathExistsSync(join(repo.commondir(), 'refs')), 'repo must have a refs directory');
     t.true(fse.pathExistsSync(join(repo.commondir(), 'refs', 'Main')), 'Main reference');


### PR DESCRIPTION
# Description

This PR introduces a simple log system. Logs are written to `./snow/logs`.

## Example

```
1615665880182 -0500 $> init: initialized at C:\Users\sebastian\Desktop\foo2
1615665880209 -0500 $> commit: Created Project
1615666315903 -0500 $> reference: creating branch-xyz at e1df41702d8f65342c1cb078478929e6d70008b446c812949225aa707d869a5d
```

- [x] New feature (non-breaking change which adds functionality)