### PR TITLE
Bugfix/issue 90 snow branch

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -10,7 +10,7 @@ import { Index } from './src/index';
 import { Commit } from './src/commit';
 import { Reference } from './src/reference';
 import {
-  StatusEntry, FILTER, Repository, RESET, COMMIT_ORDER,
+  StatusEntry, FILTER, Repository, RESET, COMMIT_ORDER, REFERENCE_TYPE,
 } from './src/repository';
 import { TreeDir, TreeFile } from './src/treedir';
 import { IoContext } from './src/io_context';
@@ -230,7 +230,7 @@ program
         }
       }
 
-      await repo.createNewReference(branchName, startPoint, startPoint, data);
+      await repo.createNewReference(REFERENCE_TYPE.BRANCH, branchName, startPoint, startPoint, data);
     } catch (error) {
       if (opts.debug) {
         throw error;
@@ -290,7 +290,7 @@ program
           }
         }
 
-        await repo.createNewReference(opts.branch, repo.getHead().hash, repo.getHead().hash, data);
+        await repo.createNewReference(REFERENCE_TYPE.BRANCH, opts.branch, repo.getHead().hash, repo.getHead().hash, data);
       } else if (target) { // snow checkout [hash]
         let reset: RESET = RESET.NONE;
         if (opts.reset) {

--- a/main.ts
+++ b/main.ts
@@ -207,6 +207,7 @@ program
 program
   .command('branch [branch-name] [start-point]')
   .option('--debug', 'add more debug information on errors')
+  .option('--delete', 'delete a branch')
   .option('--no-color')
   .option('--user-data', 'open standard input to apply user data for commit')
   .option('--input <type>', "type can be 'stdin' or {filepath}")
@@ -219,18 +220,27 @@ program
     try {
       const repo = await Repository.open(process.cwd());
 
-      opts = await parseOptions(opts);
-
-      let data = {};
-      if (opts.userData) {
-        try {
-          data = JSON.parse(opts.userData);
-        } catch (e) {
-          throw new Error(`invalid user-data: ${e}`);
+      if (opts.delete) {
+        if (startPoint) {
+          throw new Error('start-point must be empty');
         }
-      }
+        const oldTarget: string = await repo.deleteReference(REFERENCE_TYPE.BRANCH, branchName);
+        console.log(`Deleted branch '${branchName}' (was ${oldTarget})`);
+      } else {
+        opts = await parseOptions(opts);
 
-      await repo.createNewReference(REFERENCE_TYPE.BRANCH, branchName, startPoint, startPoint, data);
+        let data = {};
+        if (opts.userData) {
+          try {
+            data = JSON.parse(opts.userData);
+          } catch (e) {
+            throw new Error(`invalid user-data: ${e}`);
+          }
+        }
+
+        await repo.createNewReference(REFERENCE_TYPE.BRANCH, branchName, startPoint, data);
+        console.log(`A branch '${branchName}' got created.`);
+      }
     } catch (error) {
       if (opts.debug) {
         throw error;
@@ -290,7 +300,7 @@ program
           }
         }
 
-        await repo.createNewReference(REFERENCE_TYPE.BRANCH, opts.branch, repo.getHead().hash, repo.getHead().hash, data);
+        await repo.createNewReference(REFERENCE_TYPE.BRANCH, opts.branch, repo.getHead().hash, data);
       } else if (target) { // snow checkout [hash]
         let reset: RESET = RESET.NONE;
         if (opts.reset) {
@@ -511,7 +521,7 @@ program
             return {
               name: value.getName(),
               hash: value.hash,
-              start: value.start,
+              start: value.startHash,
               userData: value.userData ? JSON.parse(JSON.stringify(value.userData)) : {},
             };
           }

--- a/src/odb.ts
+++ b/src/odb.ts
@@ -8,7 +8,7 @@ import {
   DirItem, OSWALK, osWalk, zipFile,
 } from './io';
 
-import { Repository, RepositoryInitOptions } from './repository';
+import { REFERENCE_TYPE, Repository, RepositoryInitOptions } from './repository';
 import { Commit } from './commit';
 import { Reference } from './reference';
 import { calculateFileHash, FileInfo, HashBlock } from './common';
@@ -141,7 +141,7 @@ export class Odb {
           start: ret.content.start,
           userData: ret.content.userData,
         };
-        return new Reference(basename(ret.ref.path), this.repo, opts);
+        return new Reference(ret.content.type, basename(ret.ref.path), this.repo, opts);
       }))
       .then((refsResult: Reference[]) => refsResult);
   }
@@ -187,6 +187,7 @@ export class Odb {
 
     return fse.writeFile(refPath, JSON.stringify({
       hash: ref.hash,
+      type: ref.type,
       start: ref.start ? ref.start : undefined,
       userData: ref.userData ?? {},
     }));

--- a/src/odb.ts
+++ b/src/odb.ts
@@ -146,7 +146,7 @@ export class Odb {
       .then((refsResult: Reference[]) => refsResult);
   }
 
-  async deleteHeadReference(ref: Reference) {
+  async deleteReference(ref: Reference) {
     const refsDir: string = join(this.repo.options.commondir, 'refs');
     // writing a head to disk means that either the name of the ref is stored or the hash in case the HEAD is detached
     return fse.unlink(join(refsDir, ref.getName()));
@@ -188,7 +188,7 @@ export class Odb {
     return fse.writeFile(refPath, JSON.stringify({
       hash: ref.hash,
       type: ref.type,
-      start: ref.start ? ref.start : undefined,
+      start: ref.startHash ? ref.startHash : undefined,
       userData: ref.userData ?? {},
     }));
   }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -14,14 +14,14 @@ export class Reference {
 
     repo: Repository;
 
-    start: string;
+    startHash: string;
 
     type: REFERENCE_TYPE;
 
     constructor(type: REFERENCE_TYPE, refName: string, repo: Repository, c: {hash: string, start: string, userData?: any}) {
       this.hash = c.hash;
       this.userData = c.userData ?? {};
-      this.start = c.start;
+      this.startHash = c.start;
       this.refName = refName;
       this.repo = repo;
       this.type = type;
@@ -51,11 +51,15 @@ export class Reference {
       return this.hash;
     }
 
+    start(): string {
+      return this.startHash;
+    }
+
     clone(): Reference {
       const ref = new Reference(this.type, this.refName, this.repo,
         {
           hash: this.hash,
-          start: this.start,
+          start: this.startHash,
         });
 
       ref.userData = {};

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,4 +1,4 @@
-import { Repository } from './repository';
+import { REFERENCE_TYPE, Repository } from './repository';
 
 /**
  * A class currently representing a branch. A reference points to an existing commit through the hash (aka `target`).
@@ -16,12 +16,15 @@ export class Reference {
 
     start: string;
 
-    constructor(refName: string, repo: Repository, c: {hash: string, start: string, userData?: any}) {
+    type: REFERENCE_TYPE;
+
+    constructor(type: REFERENCE_TYPE, refName: string, repo: Repository, c: {hash: string, start: string, userData?: any}) {
       this.hash = c.hash;
       this.userData = c.userData ?? {};
       this.start = c.start;
       this.refName = refName;
       this.repo = repo;
+      this.type = type;
     }
 
     getName(): string {
@@ -30,6 +33,10 @@ export class Reference {
 
     setName(name: string) {
       this.refName = name;
+    }
+
+    getType(): REFERENCE_TYPE {
+      return this.type;
     }
 
     owner(): Repository {
@@ -45,7 +52,7 @@ export class Reference {
     }
 
     clone(): Reference {
-      const ref = new Reference(this.refName, this.repo,
+      const ref = new Reference(this.type, this.refName, this.repo,
         {
           hash: this.hash,
           start: this.start,

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -503,7 +503,7 @@ export class Repository {
    *
    * @param name  Name of the new reference
    * @param hash  Commit hash of the new reference.
-   * @param start Set commit hash of the start of the reference.
+   * @param start Set commit hash of the start of the reference. If null, 'hash' becomes the starting point
    */
   async createNewReference(type: REFERENCE_TYPE, name: string, hash: string, start?: string|null, userData?: {}): Promise<Reference> {
     const existingRef: Reference = this.references.find((ref: Reference) => ref.getName() === name);

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -503,7 +503,7 @@ export class Repository {
    *
    * @param name  Name of the new reference
    * @param hash  Commit hash of the new reference.
-   * @param start Set commit hash of the start of the reference. If null, 'hash' becomes the starting point
+   * @param start Set commit hash of the start of the reference. If null, 'hash' becomes the starting point.
    */
   async createNewReference(type: REFERENCE_TYPE, name: string, hash: string, start?: string|null, userData?: {}): Promise<Reference> {
     const existingRef: Reference = this.references.find((ref: Reference) => ref.getName() === name);

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -147,7 +147,13 @@ test.only('snow branch foo-branch', async (t) => {
   // Try to delete the HEAD branch which must fail
   error = await t.throwsAsync(async () =>
     exec(t, snow, ['branch', '--delete', checkedOutBranch], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT));
-  t.true(error.message.includes(`Cannot delete branch '${checkedOutBranch}' checked out at '${repoAfter2.workdir()}'`));
+
+  if (process.platform === 'darwin') {
+    // on macOS 'process.cwd()' in the branch command returns /private/var/...
+    t.true(error.message.includes(`Cannot delete branch '${checkedOutBranch}' checked out at '/private${repoAfter2.workdir()}'`));
+  } else {
+    t.true(error.message.includes(`Cannot delete branch '${checkedOutBranch}' checked out at '${repoAfter2.workdir()}'`));
+  }
 });
 
 test('snow add .', async (t) => {

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -86,7 +86,7 @@ test('snow add/commit/log', async (t) => {
   t.is(true, true);
 });
 
-test.only('snow branch foo-branch', async (t) => {
+test('snow branch foo-branch', async (t) => {
   t.timeout(180000);
 
   let out: string | void;

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -6,7 +6,8 @@ import * as fse from 'fs-extra';
 
 import { spawn } from 'child_process';
 import { join, dirname, basename } from 'path';
-import { COMMIT_ORDER, Repository } from '../src/repository';
+import { COMMIT_ORDER, REFERENCE_TYPE, Repository } from '../src/repository';
+import { Reference } from '../src/reference';
 
 enum EXEC_OPTIONS {
   RETURN_STDOUT = 1,
@@ -83,6 +84,70 @@ test('snow add/commit/log', async (t) => {
   }
 
   t.is(true, true);
+});
+
+test.only('snow branch foo-branch', async (t) => {
+  t.timeout(180000);
+
+  let out: string | void;
+  let error;
+  const snow: string = getSnowexec(t);
+  const snowWorkdir = generateUniqueTmpDirName();
+
+  // Create branch succesfully
+  await exec(t, snow, ['init', basename(snowWorkdir)], { cwd: dirname(snowWorkdir) });
+  t.log('Write foo.txt');
+  fse.writeFileSync(join(snowWorkdir, 'foo.txt'), 'foo');
+  await exec(t, snow, ['add', '.'], { cwd: snowWorkdir });
+  await exec(t, snow, ['commit', '-m', 'First user-commit'], { cwd: snowWorkdir });
+
+  const repoBefore = await Repository.open(snowWorkdir);
+  const headHash = repoBefore.getHead().hash;
+  const allCommits = repoBefore.getAllCommits(COMMIT_ORDER.OLDEST_FIRST);
+  const firstCommit = allCommits[0];
+  const secondCommit = allCommits[1];
+  t.log(`HEAD now at ${headHash}`);
+
+  // snow branch foo-branch
+  out = await exec(t, snow, ['branch', 'foo-branch'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
+  t.true((out as String).includes("A branch 'foo-branch' got created."));
+
+  // the hash of 'foo-branch' must match the hash
+  const repoAfter = await Repository.open(snowWorkdir);
+  t.is(headHash, repoAfter.findReferenceByName(REFERENCE_TYPE.BRANCH, 'foo-branch').target());
+
+  // Don't create a branch twice
+  // snow branch foo-branch
+  error = await t.throwsAsync(async () => exec(t, snow, ['branch', 'foo-branch'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT));
+  t.true(error.message.includes("A branch named 'foo-branch' already exists."));
+
+  // Create a branch with a different starting point
+  // snow branch bar-branch 768FF3AA8273DFEB81E7A111572C823EA0850499
+  out = await exec(t, snow, ['branch', 'bar-branch', firstCommit.hash], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
+  t.true((out as String).includes("A branch 'bar-branch' got created."));
+
+  // verify the target() and start() point are equal (in this case the
+  // start-point and target are still the same since the branch didn't move forward)
+  const repoAfter2 = await Repository.open(snowWorkdir);
+  const checkedOutBranch: string = repoAfter2.getHead().getName();
+  const fooBranch: Reference = repoAfter2.findReferenceByName(REFERENCE_TYPE.BRANCH, 'foo-branch');
+  t.is(secondCommit.hash, fooBranch.target());
+  t.is(secondCommit.hash, fooBranch.start());
+
+  const barBranch: Reference = repoAfter2.findReferenceByName(REFERENCE_TYPE.BRANCH, 'bar-branch');
+  t.is(firstCommit.hash, barBranch.target());
+  t.is(firstCommit.hash, barBranch.start());
+
+  // Delete foo-branch and bar branch
+  out = await exec(t, snow, ['branch', '--delete', 'foo-branch'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
+  t.true((out as String).includes(`Deleted branch 'foo-branch' (was ${fooBranch.target()})`));
+  out = await exec(t, snow, ['branch', '--delete', 'bar-branch'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
+  t.true((out as String).includes(`Deleted branch 'bar-branch' (was ${barBranch.target()})`));
+
+  // Try to delete the HEAD branch which must fail
+  error = await t.throwsAsync(async () =>
+    exec(t, snow, ['branch', '--delete', checkedOutBranch], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT));
+  t.true(error.message.includes(`Cannot delete branch '${checkedOutBranch}' checked out at '${repoAfter2.workdir()}'`));
 });
 
 test('snow add .', async (t) => {


### PR DESCRIPTION
This PR is one of a multi-series commits which introduces `snow branch` described in #90.



# snow-branch

Create, or delete branches.

## Description

Create and delete a branch.

```
$ snow branch branch-foo
A branch 'branch-foo' got created.
```

Create an existing branch

```
$ snow branch branch-foo
fatal: A branch named 'branch-foo' already exists.
```

Create an existing branch with a commit hash as a starting point

```
$ snow branch branch-bar 768FF3AA8273DFEB81E7A111572C823EA0850499
A branch 'branch-foo' got created.
```

Create a branch that already exists

```
$ snow branch -f branch-foo
A branch named 'branch-foo' got created.
```

Delete a branch

```
$ snow branch --delete branch-foo
A branch named 'branch-foo' got deleted.
```

Delete a non-existing branch.

```
$ snow branch --delete branch-foo
error: branch 'branch-foo' not found.
```

For more information see: [git-branch](https://git-scm.com/docs/git-branch)

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update