### PR TITLE
:bug: add TS_NODE_TRANSPILE_ONLY to speedup compilation

### DIFF
--- a/bin/snow
+++ b/bin/snow
@@ -17,4 +17,5 @@ if [[ -z "${SUPPRESS_BANNER}" ]]; then
     echo "                For production build visit https://github.com/Snowtrack/SnowFS/releases"
 fi
 
+export TS_NODE_TRANSPILE_ONLY=true
 $node_executable -r $0/../../node_modules/ts-node/register $0/../../main.ts "$@"

--- a/bin/snow.bat
+++ b/bin/snow.bat
@@ -19,6 +19,7 @@ if NOT DEFINED SUPPRESS_BANNER (
   echo To download a production build, visit the release page at: https://github.com/Snowtrack/SnowFS/releases
 )
 
+set TS_NODE_TRANSPILE_ONLY=true
 "%_prog%" -r "%dp0%..\node_modules\ts-node\register\index.js" "%dp0%..\main.ts" %* 
 ENDLOCAL 
 EXIT /b %errorlevel% 


### PR DESCRIPTION
Use `TS_NODE_TRANSPILE_ONLY` to speedup compilation speed as recommended [here](https://github.com/TypeStrong/ts-node/discussions/1276#discussioncomment-489839).

The type-checking is done by `npm run build` before.