### PR TITLE
Bugfix/issue 90 snow switch

### DIFF
--- a/benchmarks/snowfs-vs-git.ts
+++ b/benchmarks/snowfs-vs-git.ts
@@ -182,7 +182,7 @@ export async function snowFsRestoreTexture(repoPath: string, t: any = console): 
 
   const t0 = new Date().getTime();
   const commit = repo.getCommitByHash(repo.getCommitByHead().parent[0]);
-  repo.restore(commit, RESET.RESTORE_DELETED_FILES);
+  repo.checkout(commit, RESET.RESTORE_DELETED_FILES);
   return new Date().getTime() - t0;
 }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -676,14 +676,17 @@ export class Repository {
         // Files which existed before, and still do, but check if they were modified
 
         const promises = [];
-        const existingFiles = intersection(currentFiles, oldFilePaths);
-        for (const existingFile of existingFiles) {
-          const tfile: TreeFile = oldFilesMap.get(existingFile);
-          if (!tfile) {
-            throw new Error(`File '${tfile.path}' not found during last-modified-check`);
-          }
 
-          promises.push(tfile.isFileModified(this));
+        if (reset & RESET.DELETE_MODIFIED_FILES) {
+          const existingFiles = intersection(currentFiles, oldFilePaths);
+          for (const existingFile of existingFiles) {
+            const tfile: TreeFile = oldFilesMap.get(existingFile);
+            if (!tfile) {
+              throw new Error(`File '${tfile.path}' not found during last-modified-check`);
+            }
+
+            promises.push(tfile.isFileModified(this));
+          }
         }
 
         return Promise.all(promises);

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -394,10 +394,10 @@ export class Repository {
    * The reference names can be acquired by [[Repository.getAllReferences]].
    * `name` can also be `HEAD`.
    */
-  findCommitByReferenceName(name: string): Commit|null {
-    let ref: Reference = this.references.find((ref: Reference) => ref.getName() === name);
+  findCommitByReferenceName(type: REFERENCE_TYPE, refName: string): Commit|null {
+    let ref: Reference = this.references.find((r: Reference) => r.getName() === refName && r.getType() === type);
     if (!ref) {
-      ref = (name === 'HEAD') ? this.head : null;
+      ref = (refName === 'HEAD') ? this.head : null;
     }
     if (!ref) {
       return null;
@@ -570,7 +570,7 @@ export class Repository {
    * @param target    Reference, commit or commit hash.
    * @param reset     Options for the restore operation.
    */
-  async restore(target: string|Reference|Commit, reset: RESET): Promise<void> {
+  async checkout(target: string|Reference|Commit, reset: RESET): Promise<void> {
     let oldFilePaths: string[];
     let oldFilesMap: Map<string, TreeFile>;
     const currentFiles: string[] = [];
@@ -707,7 +707,7 @@ export class Repository {
    * controlled by the passed filter.
    * @param filter  Defines which entries the function returns
    */
-  async getStatus(filter?: FILTER): Promise<StatusEntry[]> {
+  async getStatus(filter?: FILTER, commit?: Commit): Promise<StatusEntry[]> {
     let oldFilesMap: Map<string, TreeFile>;
     let oldFilePaths: string[];
     const statusResult: StatusEntry[] = [];

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -86,7 +86,7 @@ test('snow add/commit/log', async (t) => {
   t.is(true, true);
 });
 
-test.only('snow switch', async (t) => {
+test('snow switch', async (t) => {
   t.timeout(180000);
 
   let out: string | void;

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -162,12 +162,15 @@ test.only('snow switch', async (t) => {
   t.true(lines.includes('M abc0.txt')); // abc0.txt got added in the working dir
   t.true(lines.includes("fatal: You have local changes to 'branch-0'; not switching branches."));
 
-  // switch and discard the local changes
+  t.log('Switch and discard the local changes');
   await exec(t, snow, ['switch', 'branch-0', '--discard-changes'], { cwd: snowWorkdir });
   dirItems = await osWalk(snowWorkdir, OSWALK.FILES);
   dirPaths = dirItems.map((d) => basename(d.path));
   t.is(dirItems.length, 1);
   t.true(dirPaths.includes('abc0.txt'));
+
+  t.log('Switch back to branch-2 and go from there');
+  await exec(t, snow, ['switch', 'branch-2', '--discard-changes'], { cwd: snowWorkdir });
 
   t.log('Make some changes again to the working directory');
   t.log('  Update abc0.txt');

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -140,8 +140,6 @@ test.only('snow switch', async (t) => {
   t.true(dirPaths.includes('abc1.txt'));
   t.true(dirPaths.includes('abc2.txt'));
 
-  let lines: string[];
-
   t.log('Make some changes to the working directory');
   t.log('  Update abc0.txt');
   fse.writeFileSync(join(snowWorkdir, 'abc0.txt'), 'Hello World Fooooo');
@@ -156,7 +154,7 @@ test.only('snow switch', async (t) => {
   // ... and one added (abc.txt)
 
   const error = await t.throwsAsync(async () => exec(t, snow, ['switch', 'branch-0'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT));
-  lines = error.message.split('\n');
+  const lines = error.message.split('\n');
   t.true(lines.includes('A abc3.txt')); // abc3.txt got added in the working dir
   t.true(lines.includes('D abc1.txt')); // abc1.txt got added in the working dir
   t.true(lines.includes('M abc0.txt')); // abc0.txt got added in the working dir
@@ -179,9 +177,14 @@ test.only('snow switch', async (t) => {
   fse.writeFileSync(join(snowWorkdir, 'abc3.txt'), 'Hello World 3');
   fse.removeSync(join(snowWorkdir, 'abc1.txt'));
 
-  // switch back to branch-3 so we can switch back to branch-0 but this time we keep our working directory changes
+  // switch back to branch-0 and keep all changes
   await exec(t, snow, ['switch', 'branch-0', '--keep-changes'], { cwd: snowWorkdir });
-  console.log('foo');
+
+  // carried over the changes
+  t.is(fse.readFileSync(join(snowWorkdir, 'abc0.txt')).toString(), 'Hello World Fooooo');
+  t.is(fse.readFileSync(join(snowWorkdir, 'abc2.txt')).toString(), 'Hello World 2');
+  t.is(fse.readFileSync(join(snowWorkdir, 'abc3.txt')).toString(), 'Hello World 3');
+  t.false(fse.pathExistsSync(join(snowWorkdir, 'abc1.txt')));
 });
 
 test('snow branch foo-branch', async (t) => {

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -170,7 +170,7 @@ test.only('snow switch', async (t) => {
   t.true(dirPaths.includes('abc0.txt'));
 
   t.log('Switch back to branch-2 and go from there');
-  await exec(t, snow, ['switch', 'branch-2', '--discard-changes'], { cwd: snowWorkdir });
+  await exec(t, snow, ['switch', 'branch-2'], { cwd: snowWorkdir });
 
   t.log('Make some changes again to the working directory');
   t.log('  Update abc0.txt');


### PR DESCRIPTION
This PR is one of a multi-series commits which introduces `snow switch` described in #90.

# snow-switch

Switch branches. **Any modifications in the stage area, or in the worktree are brought over to the switched branch.**

## Description

Switch to an existing branch.

```
$ snow switch branch-foo
# Silently switch to branch
```

Switch to a non-existing branch.

```
$ snow switch branch-123
fatal: A branch named 'branch-123' does not exist.
```

Switch incorrectly to a commit. To checkout a commit see `snow-checkout`.

```
$ snow switch 6cfb01e83d18fa63761e964c329273d292d23bb4
fatal: a branch is expected, got commit '6cfb01e83d18fa63761e964c329273d292d23bb4'
```

Create and switch to a branch. Short command for `snow-branch` and `snow-switch`

```
$ snow switch -c branch-bar
A branch 'branch-bar' got created.
# Afterwards silently switch to branch
```

Create and switch to a branch with a start-point.

```
$ snow switch -c branch-bas 768FF3AA8273DFEB81E7A111572C823EA0850499
A branch 'branch-bas' got created.
```

For more information see: [git-switch](https://git-scm.com/docs/git-switch)