### PR TITLE
:star: introduce fss.writeSafeFile

### DIFF
--- a/src/fs-safe.ts
+++ b/src/fs-safe.ts
@@ -1,0 +1,32 @@
+import * as fse from 'fs-extra';
+import * as crypto from 'crypto';
+
+/**
+ * Asynchronously writes data to a file, replacing the file if it already exists.
+ * In comparision to `fs.writeFile`, this function ensures that the file got written
+ * to disk successfully before placing it at the expected path. This is achieved by
+ * an atomic **rename** of a temporary file, where the content is first written to.
+ * `data` can be a string, a buffer, or an object with an own toString function property.
+ * The promise is resolved with no arguments upon success.
+ *
+ *
+ * @param path      Path of the target file.
+ * @param data      Data object to write to the file
+ * @param options   For more information see the [docs](https://nodejs.org/api/fs.html#fs_filehandle_writefile_data_options)
+ * @returns
+ */
+export async function writeSafeFile(path: string, data: any, options?: string | fse.WriteFileOptions) {
+  const tmp = crypto.createHash('sha256').update(process.hrtime().toString()).digest('hex').substring(0, 6);
+  const tmpPath: string = `${path}.${tmp}.tmp`;
+
+  return fse.writeFile(tmpPath, data, options)
+    .then(() => fse.rename(tmpPath, path))
+    .catch((err) => {
+      try {
+        fse.unlinkSync(tmpPath);
+      } catch (err2) {
+        console.log(err2);
+      }
+      throw err;
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import * as fse from 'fs-extra';
-import * as crypto from 'crypto';
 
 import { difference, intersection } from 'lodash';
 
 import {
   isAbsolute, join, relative, basename,
 } from 'path';
+import * as fss from './fs-safe';
 import { IoContext } from './io_context';
 import { Odb } from './odb';
 import { Repository } from './repository';
@@ -126,8 +126,7 @@ export class Index {
       }
       return value;
     });
-
-    return fse.ensureDir(Index.getAbsDir(this.repo)).then(() => fse.writeFile(this.getAbsPath(), userData));
+    return fse.ensureDir(Index.getAbsDir(this.repo)).then(() => fss.writeSafeFile(this.getAbsPath(), userData));
   }
 
   /**

--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -213,17 +213,6 @@ export class IoContext {
     return i === j;
   }
 
-  /**
-   * Moves a file or directory, even across devices.
-   * @param src   source filename to move
-   * @param dst   destination filename of the move operation
-   * @param options  overwrite existing file or directory, default is `false`.
-   */
-  async move(src: string, dst: string, options?: fse.MoveOptions): Promise<void> {
-    this.checkIfInitialized();
-    return fse.move(src, dst, options);
-  }
-
   private async copyFileApfs(src: string, dst: string): Promise<void> {
     return fse.stat(src).then((stat: fse.Stats) => {
       // TODO: (Need help)

--- a/src/odb.ts
+++ b/src/odb.ts
@@ -7,8 +7,9 @@ import {
 import {
   DirItem, OSWALK, osWalk, zipFile,
 } from './io';
+import * as fss from './fs-safe';
 
-import { REFERENCE_TYPE, Repository, RepositoryInitOptions } from './repository';
+import { Repository, RepositoryInitOptions } from './repository';
 import { Commit } from './commit';
 import { Reference } from './reference';
 import { calculateFileHash, FileInfo, HashBlock } from './common';
@@ -155,7 +156,7 @@ export class Odb {
   async writeHeadReference(head: Reference) {
     const refsDir: string = this.repo.options.commondir;
     // writing a head to disk means that either the name of the ref is stored or the hash in case the HEAD is detached
-    return fse.writeFile(join(refsDir, 'HEAD'), head.getName() === 'HEAD' ? head.hash : head.getName());
+    return fss.writeSafeFile(join(refsDir, 'HEAD'), head.getName() === 'HEAD' ? head.hash : head.getName());
   }
 
   async readHeadReference(): Promise<string | null> {
@@ -185,7 +186,7 @@ export class Odb {
 
     const refPath = join(refsDir, ref.getName());
 
-    return fse.writeFile(refPath, JSON.stringify({
+    return fss.writeSafeFile(refPath, JSON.stringify({
       hash: ref.hash,
       type: ref.type,
       start: ref.startHash ? ref.startHash : undefined,
@@ -263,7 +264,7 @@ export class Odb {
       .then(() => {
         if (hashBlocks) {
           const content: string = hashBlocks.map((block: HashBlock) => `${block.start};${block.end};${block.hash};`).join('\n');
-          return fse.writeFile(`${dstFile}.hblock`, content);
+          return fss.writeSafeFile(`${dstFile}.hblock`, content);
         }
         return Promise.resolve();
       })

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -609,7 +609,7 @@ test('compareFileHash test', async (t) => {
   }
 });
 
-test.only('fss.writeSafeFile test', async (t) => {
+test('fss.writeSafeFile test', async (t) => {
   try {
     const tmpDir = fse.mkdtempSync(join(os.tmpdir(), 'snowtrack-'));
     const tmpFile = join(tmpDir, 'foo.txt');


### PR DESCRIPTION
Introduce `fss.writeSafeFile` to write files to disk atomically, but writing the file first to disk and then doing a rename (which is atomically).