### PR TITLE
Add support for branch~n

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -474,6 +474,9 @@ export class Repository {
       for (const idx of hash.split('~')) {
         if (idx === 'HEAD') {
           commit = this.commitMap.get(this.getHead().hash);
+        } else if (this.references.map((r: Reference) => r.getName()).includes(idx)) {
+          const ref = this.references.find((r: Reference) => r.getName() === idx);
+          commit = this.commitMap.get(ref.target());
         } else if (commit) {
           const iteration: number = parseInt(idx, 10);
           if (Number.isNaN(iteration)) {

--- a/test/4.repo.commit.ts
+++ b/test/4.repo.commit.ts
@@ -261,6 +261,10 @@ test('HEAD~n', async (t) => {
   res = repo.findCommitByHash('HEAD~1');
   t.is(res.hash, commit4.hash);
 
+  t.log('Test Main~1');
+  res = repo.findCommitByHash('Main~1');
+  t.is(res.hash, commit4.hash);
+
   t.log('Test HEAD~2');
   res = repo.findCommitByHash('HEAD~2');
   t.is(res.hash, commit3.hash);


### PR DESCRIPTION
Add support for commit lookup `branch~n`, like `Main~1`. This is an extension of `HEAD~1` where from now on, also the branch can be used.

- [x] New feature (non-breaking change which adds functionality)