### PR TITLE
Bugfix/issue 148

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 logs
 docs
 dist
+tmp
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/benchmark/snowfs-vs-git.ts
+++ b/benchmark/snowfs-vs-git.ts
@@ -184,7 +184,7 @@ export async function snowFsRestoreTexture(repoPath: string, t: any = console): 
 
   const t0 = new Date().getTime();
   const commit = repo.findCommitByHash('HEAD~1');
-  await repo.checkout(commit, RESET.RESTORE_DELETED_FILES);
+  await repo.checkout(commit, RESET.RESTORE_DELETED_ITEMS);
   return new Date().getTime() - t0;
 }
 

--- a/benchmark/snowfs-vs-git.ts
+++ b/benchmark/snowfs-vs-git.ts
@@ -3,7 +3,6 @@ import * as readline from 'readline';
 import * as fse from 'fs-extra';
 import * as crypto from 'crypto';
 import * as os from 'os';
-import * as tty from 'tty';
 import { dirname, join, basename } from '../src/path';
 import { Repository, RESET } from '../src/repository';
 
@@ -188,7 +187,7 @@ export async function snowFsRestoreTexture(repoPath: string, t: any = console): 
   return new Date().getTime() - t0;
 }
 
-export async function startBenchmark(textureFilesize: number = BENCHMARK_FILE_SIZE, t: any = console) {
+export async function startBenchmark(textureFilesize: number = BENCHMARK_FILE_SIZE, t: any = console): Promise<void> {
   let playground: string;
   while (true) {
     const desktop = join(os.homedir(), 'desktop');
@@ -239,5 +238,11 @@ export async function startBenchmark(textureFilesize: number = BENCHMARK_FILE_SI
 }
 
 if (process.env.NODE_ENV === 'benchmark') {
-  startBenchmark();
+  (async () => {
+    try {
+      await startBenchmark();
+    } catch (e) {
+      process.stderr.write(e.message);
+    }
+  })();
 }

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ import { IoContext } from './src/io_context';
 const program = require('commander');
 const chalk = require('chalk');
 const drivelist = require('drivelist');
+const AggregateError = require('es-aggregate-error');
 
 function fileMatch(relFilepath: string, relCwd: string, pathPattern: string): boolean {
   return pathPattern === '*' || (pathPattern === '.' && relFilepath.startsWith(relCwd)) || pathPattern === relative(relCwd, relFilepath);
@@ -128,7 +129,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -159,7 +164,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -198,7 +207,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -245,7 +258,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -309,7 +326,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -332,7 +353,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -414,7 +439,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -459,7 +488,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -595,7 +628,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }
@@ -681,7 +718,11 @@ program
       if (opts.debug) {
         throw error;
       } else {
-        process.stderr.write(`fatal: ${error.message}\n`);
+        if (error instanceof AggregateError) {
+          process.stderr.write(`fatal: ${error.errors.map((e) => e.message).join('\n')}`);
+        } else {
+          process.stderr.write(`fatal: ${error.message}\n`);
+        }
         process.exit(-1);
       }
     }

--- a/main.ts
+++ b/main.ts
@@ -300,7 +300,7 @@ program
 
         let reset: RESET = RESET.DETACH; // checkout always results in a detached HEAD
         if (!opts.keepChanges) {
-          reset |= RESET.RESTORE_MODIFIED_FILES | RESET.DELETE_NEW_FILES | RESET.RESTORE_DELETED_FILES;
+          reset |= RESET.RESTORE_MODIFIED_ITEMS | RESET.DELETE_NEW_ITEMS | RESET.RESTORE_DELETED_ITEMS;
         }
 
         await repo.checkout(target, reset);
@@ -669,7 +669,7 @@ program
 
         let reset: RESET = RESET.NONE;
         if (!opts.keepChanges) {
-          reset |= RESET.RESTORE_MODIFIED_FILES | RESET.DELETE_NEW_FILES | RESET.RESTORE_DELETED_FILES;
+          reset |= RESET.RESTORE_MODIFIED_ITEMS | RESET.DELETE_NEW_ITEMS | RESET.RESTORE_DELETED_ITEMS;
         }
         if (opts.detach) {
           reset |= RESET.DETACH;

--- a/main.ts
+++ b/main.ts
@@ -75,7 +75,7 @@ async function parseOptions(opts: any) {
         rl.close();
       });
 
-      tmp = await new Promise<string>((resolve, reject) => {
+      tmp = await new Promise<string>((resolve, _reject) => {
         rl.on('close', () => {
           resolve(res);
         });
@@ -646,13 +646,6 @@ program
     const drives = await drivelist.list();
     console.log(JSON.stringify(drives, null, opts.output === 'json' ? '' : '    '));
   });
-
-const switchDesc = `switch a commit, or create a branch
-  
-  ${chalk.bold('Examples')}
-  
-      switch to a branch
-        $ snow switch branch-name`;
 
 program
   .command('switch [branch-name]')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1097,7 +1097,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1533,7 +1532,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1722,7 +1720,6 @@
       "version": "1.18.0-next.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
       "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -1740,11 +1737,23 @@
         "string.prototype.trimstart": "^1.0.3"
       }
     },
+    "es-aggregate-error": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.5.tgz",
+      "integrity": "sha512-lCJhahEBlzD0WnPEpFCWqjxm4DI4fzuq1PVxLfsGdHImCWSUhASlv+lrBX4Wc47g62SAO4+axBUfUMgJYIhilg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "function-bind": "^1.1.1",
+        "functions-have-names": "^1.2.1",
+        "get-intrinsic": "^1.0.1",
+        "globalthis": "^1.0.1"
+      }
+    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -2425,14 +2434,18 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
     },
     "gauge": {
       "version": "2.7.4",
@@ -2498,7 +2511,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -2575,6 +2587,14 @@
         "type-fest": "^0.8.1"
       }
     },
+    "globalthis": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
@@ -2646,7 +2666,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -2659,8 +2678,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -2835,8 +2853,7 @@
     "is-callable": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-      "dev": true
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -2859,8 +2876,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-error": {
       "version": "2.2.2",
@@ -2908,8 +2924,7 @@
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
     },
     "is-npm": {
       "version": "5.0.0",
@@ -2956,7 +2971,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
       "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
@@ -2978,7 +2992,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -3806,20 +3819,17 @@
     "object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-      "dev": true
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -5112,7 +5122,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
       "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"
@@ -5122,7 +5131,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
       "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "chalk": "^4.1.0",
     "commander": "^7.0.0",
     "drivelist": "^9.2.4",
+    "es-aggregate-error": "^1.0.5",
     "fs-extra": "^9.0.1",
     "lodash": "^4.17.20",
     "micromatch": "^4.0.2",

--- a/src/fs-safe.ts
+++ b/src/fs-safe.ts
@@ -2,7 +2,7 @@ import * as fse from 'fs-extra';
 import * as crypto from 'crypto';
 
 /**
- * Asynchronously writes data to a file, replacing the file if it already exists.
+ * Write data to a file and replacing the file if it already exists.
  * In comparision to `fs.writeFile`, this function ensures that the file got written
  * to disk successfully before placing it at the expected path. This is achieved by
  * an atomic **rename** of a temporary file, where the content is first written to.

--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -146,9 +146,9 @@ export async function whichFilesInDirAreOpen(dirpath: string): Promise<Map<strin
 function getFilesystem(drive: any, mountpoint: string) {
   try {
     if (process.platform === 'win32') {
-      return new Promise<string | null>((resolve, reject) => {
+      return new Promise<string | null>((resolve, _reject) => {
         const driveLetter = mountpoint.endsWith('\\') ? mountpoint.substring(0, mountpoint.length - 1) : mountpoint;
-        exec(`fsutil fsinfo volumeinfo ${driveLetter}`, (error, stdout, stderr) => {
+        exec(`fsutil fsinfo volumeinfo ${driveLetter}`, (error, stdout, _stderr) => {
           if (error) {
             return resolve(null); // if we can't extract the volume info, we simply skip the ReFS detection
           }
@@ -240,12 +240,12 @@ export class IoContext {
    * Invalidates the internal device storage information.
    * Normally not needed to explicitly call.
    */
-  invalidate() {
+  invalidate(): void {
     this.valid = false;
     this.mountpoints = undefined;
   }
 
-  checkIfInitialized() {
+  checkIfInitialized(): void {
     if (!this.valid) {
       throw new Error('IoContext is not initialized, did you forget to call IoContext.init(..)?');
     }
@@ -257,7 +257,7 @@ export class IoContext {
    * the path of the executable.
    * @param execPath  Path to the executable. Fails if the file does not exist or the path is a directory.
    */
-  static setTrashExecPath(execPath: string) {
+  static setTrashExecPath(execPath: string): void {
     if (!fse.pathExistsSync(execPath)) {
       throw new Error(`path ${execPath} does not exist`);
     }

--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -3,10 +3,22 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 
 import { exec, spawn } from 'child_process';
-import { join, dirname, normalize } from './path';
+import {
+  join, dirname, normalize, relative,
+} from './path';
 import { MB1 } from './common';
 
+// if Node version 15, switch to built-in AggregateError
+const AggregateError = require('es-aggregate-error');
 const drivelist = require('drivelist');
+
+class StacklessError extends Error {
+  constructor(...args) {
+    super(...args);
+    this.name = this.constructor.name;
+    delete this.stack;
+  }
+}
 
 export enum FILESYSTEM {
   APFS = 1,
@@ -27,6 +39,109 @@ export class Drive {
     this.displayName = displayName;
     this.filesystem = filesystem;
   }
+}
+
+export namespace unix {
+
+/**
+ * Possible file lock types on a given file. This are the extracted
+ * information from a `man lsof` converted into an enum.
+ */
+export enum LOCKTYPE {
+  NFS_LOCK = 'N', // for a Solaris NFS lock of unknown type
+  READ_LOCK_FILE_PART = 'r', // for read lock on part of the file
+  READ_LOCK_FILE = 'R', // for a read lock on the entire file
+  WRITE_LOCK_FILE_PART = 'w', // for a write lock on part of the file
+  WRITE_LOCK_FILE = 'W', // for a write lock on the entire file
+  READ_WRITE_LOCK_FILE = 'u', // for a read and write lock of any length
+  UNKNOWN = 'X' // An unknown lock type (U, x or X)
+}
+
+export class FileHandle {
+  /** PID of process which acquired the file handle */
+  pid: string;
+
+  processname: string;
+
+  /** File access information with file lock info */
+  lockType: LOCKTYPE;
+
+  /** Documents filepath */
+  filepath: string;
+}
+
+export async function whichFilesInDirAreOpen(dirpath: string): Promise<Map<string, FileHandle[]>> {
+  try {
+    return new Promise<Map<string, FileHandle[]>>((resolve, reject) => {
+      const p0 = cp.spawn('lsof', ['-X', '-F', 'pcan', '+D', dirpath]);
+      const p = new Map<string, FileHandle[]>();
+
+      let stdout = '';
+      p0.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      function parseStdout(stdout: string) {
+        let lsofEntry: FileHandle = new FileHandle();
+        for (const pline of stdout.split(/\n/)) {
+          if (pline.startsWith('p')) { // PID of process which acquired the file handle
+            // first item, therefore it creates the file handle
+            lsofEntry = new FileHandle();
+            lsofEntry.pid = pline.substr(1, pline.length - 1);
+          } else if (pline.startsWith('c')) { // Name of process which acquired the file handle
+            lsofEntry.processname = pline.substr(1, pline.length - 1);
+          } else if (pline.startsWith('a')) { // File access information with file lock info
+            // See `LOCKTYPE` for more information
+            if (pline.includes('N')) {
+              lsofEntry.lockType = LOCKTYPE.NFS_LOCK;
+            } else if (pline.includes('r')) {
+              lsofEntry.lockType = LOCKTYPE.READ_LOCK_FILE_PART;
+            } else if (pline.includes('R')) {
+              lsofEntry.lockType = LOCKTYPE.READ_LOCK_FILE;
+            } else if (pline.includes('w')) {
+              lsofEntry.lockType = LOCKTYPE.WRITE_LOCK_FILE_PART;
+            } else if (pline.includes('W')) {
+              lsofEntry.lockType = LOCKTYPE.WRITE_LOCK_FILE;
+            } else if (pline.includes('u')) {
+              lsofEntry.lockType = LOCKTYPE.READ_WRITE_LOCK_FILE;
+            } else {
+              lsofEntry.lockType = LOCKTYPE.UNKNOWN;
+            }
+          } else if (pline.startsWith('n')) { // Documents filepath
+            const absPath = pline.substr(1, pline.length - 1);
+            if (absPath.startsWith(dirpath)) {
+              const relPath = relative(dirpath, pline.substr(1, pline.length - 1));
+              const q = p.get(relPath);
+              if (q) {
+                // if there was an entry before, add the new entry to the array in the map
+                q.push(lsofEntry);
+              } else {
+                // ..otherwise add a new list with the lsofEntry as the first element
+                p.set(relPath, [lsofEntry]);
+              }
+              lsofEntry = new FileHandle();
+            } else {
+              console.log(`lsof reported unknown path: ${absPath}`);
+            }
+          }
+        }
+      }
+
+      p0.on('exit', (code) => {
+        if (code === 1) { // lsof returns 1
+          parseStdout(stdout);
+          resolve(p);
+        } else {
+          reject(code);
+        }
+      });
+    });
+  } catch (error) {
+    console.log(error);
+    return new Map();
+  }
+}
+
 }
 
 function getFilesystem(drive: any, mountpoint: string) {
@@ -307,6 +422,106 @@ export class IoContext {
         return fse.copyFile(src, dst, fse.constants.COPYFILE_FICLONE);
       default:
         throw new Error('Unsupported Operating System');
+    }
+  }
+
+  /**
+   * Check if the given filepaths are write-locked by another process.
+   * For more information, or to add comments visit https://github.com/Snowtrack/SnowFS/discussions/110
+   *
+   * @param dir               The root directory path to check
+   * @param relPaths          Relative file paths inside the given directory.
+   * @throws {AggregateError} Aggregated error of StacklessError
+   */
+  performWriteLockChecks(dir: string, relPaths: string[]): Promise<void> {
+    function checkWin32(relPaths): Promise<void> {
+      const absPaths = relPaths.map((p: string) => join(dir, p));
+
+      const promises = [];
+
+      for (const absPath of absPaths) {
+        promises.push(fse.stat(absPath));
+      }
+
+      const stats1 = new Map<string, number>();
+
+      return Promise.all(promises)
+        .then((stats: fse.Stats[]) => {
+          if (stats.length !== relPaths.length) {
+            throw new Error('Internal error: stats != paths');
+          }
+
+          for (let i = 0; i < relPaths.length; ++i) {
+            stats1.set(relPaths[i], stats[i].size);
+          }
+
+          return new Promise<void>((resolve) => {
+            setTimeout(() => {
+              resolve();
+            }, 500);
+          });
+        }).then(() => {
+          const promises = [];
+
+          for (const absPath of absPaths) {
+            promises.push(fse.stat(absPath));
+          }
+
+          return Promise.all(promises);
+        }).then((stats: fse.Stats[]) => {
+          if (stats.length !== relPaths.length) {
+            throw new Error('Internal error: stats != paths');
+          }
+
+          const errors: Error[] = [];
+
+          for (let i = 0; i < relPaths.length; ++i) {
+            const prevSize = stats1.get(relPaths[i]);
+            if (prevSize !== stats[i].size) {
+              const msg = `File '${relPaths[i]}' is written by another process`;
+              errors.push(new StacklessError(msg));
+            }
+          }
+
+          if (errors.length > 0) {
+            throw new AggregateError(errors);
+          }
+        });
+    }
+
+    function checkUnixLike(relPaths): Promise<void> {
+      return unix.whichFilesInDirAreOpen(dir)
+        .then((fileHandles: Map<string, unix.FileHandle[]>) => {
+          const errors: Error[] = [];
+
+          for (const relPath of relPaths) {
+            const fhs: unix.FileHandle[] = fileHandles.get(relPath);
+            if (fhs) {
+              for (const fh of fhs) {
+                if (fh.lockType === unix.LOCKTYPE.READ_WRITE_LOCK_FILE
+                    || fh.lockType === unix.LOCKTYPE.WRITE_LOCK_FILE
+                    || fh.lockType === unix.LOCKTYPE.WRITE_LOCK_FILE_PART) {
+                  const msg = `File '${relPath}' is written by ${fh.processname ?? 'another process'}`;
+                  errors.push(new StacklessError(msg));
+                }
+              }
+            }
+          }
+
+          if (errors.length > 0) {
+            throw new AggregateError(errors);
+          }
+        });
+    }
+
+    switch (process.platform) {
+      case 'win32':
+        return checkWin32(relPaths);
+      case 'darwin':
+      case 'linux':
+        return checkUnixLike(relPaths);
+      default:
+        throw new Error('Unknown operating system');
     }
   }
 

--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -8,7 +8,6 @@ import {
 } from './path';
 import { MB1 } from './common';
 
-// if Node version 15, switch to built-in AggregateError
 const AggregateError = require('es-aggregate-error');
 const drivelist = require('drivelist');
 

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,12 +1,17 @@
 import * as path from 'path';
 
-export { sep, basename, isAbsolute } from 'path';
+export {
+  sep, basename, isAbsolute,
+} from 'path';
 
 /**
  * Normalizes a path by using `path.normalize()` internally, and discarding a trailing directory delimiter.
+ * If a path normalizes to the root ('/'), this will be returned
  *
- * Input: /Users/snowtrack/Desktop/../foo/
- * Output: /Users/snowtrack/foo
+ * Input: '/Users/snowtrack/Desktop/../foo/'
+ * Output: '/Users/snowtrack/foo'
+ * Input: '/'
+ * Output: '/'
  *
  * @param p Required. A string. The path you want to normalize.
  * @returns    A String, representing the normalized path
@@ -18,7 +23,9 @@ export function normalize(p: string): string {
   }
 
   p = path.normalize(p).replace(/\\/g, '/');
-  if (p.endsWith('/')) {
+
+  // strip away trailing slashes
+  if (p !== '/' && p.endsWith('/')) {
     p = p.substr(0, p.length - 1);
   }
   return p;

--- a/src/path.ts
+++ b/src/path.ts
@@ -31,7 +31,7 @@ export function normalize(p: string): string {
   return p;
 }
 
-export function normalizeExt(p: string, sep: string): string {
+export function normalizeExt(p: string): string {
 // empty path stays an empty path, otherwise would return '.'
   if (p === '' || p === '.') {
     return '';
@@ -44,22 +44,22 @@ export function normalizeExt(p: string, sep: string): string {
   return p.replace('/', path.sep);
 }
 
-export function join(...paths: string[]) {
+export function join(...paths: string[]): string {
   return normalize(path.join(...paths));
 }
 
-export function dirname(p: string) {
+export function dirname(p: string): string {
   return normalize(path.dirname(p));
 }
 
-export function resolve(...pathSegments: string[]) {
+export function resolve(...pathSegments: string[]): string {
   return normalize(path.resolve(...pathSegments));
 }
 
-export function relative(from: string, to: string) {
+export function relative(from: string, to: string): string {
   return normalize(path.relative(from, to));
 }
 
-export function extname(p: string) {
+export function extname(p: string): string {
   return path.extname(p);
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -704,7 +704,6 @@ export class Repository {
             if (status.isFile()) {
               const tfile: TreeEntry = oldFilesMap.get(status.path);
               if (tfile) {
-                relPathChecks.push(status.path);
                 tasks.push(() => this.repoOdb.readObject(tfile.hash, dst, ioContext));
               } else {
                 throw new Error("item was detected as deleted but couldn't be found in reference commit");

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -629,7 +629,11 @@ async function sleep(delay) {
 }
 
 async function performWriteLockCheckTest(t, fileCount: number) {
-  t.pass(fileCount ?? 1);
+  if (fileCount === 0) {
+    t.plan(1); // in that case t.true(true) is checked nothing is reported
+  } else {
+    t.plan(fileCount + 2); // +2 because of 2 additional checks for no-file-handle.txt and read-file-handle.txt
+  }
 
   const tmp = join(process.cwd(), 'tmp');
   fse.ensureDirSync(tmp);
@@ -648,7 +652,7 @@ async function performWriteLockCheckTest(t, fileCount: number) {
   fse.writeFileSync(absReadFileHandleFile, 'single read-handle is on this file');
   fileHandles.set(readFileHandleFile, fse.createReadStream(absReadFileHandleFile, { flags: 'r' }));
 
-  for (let i = 0; i < fileCount + 10; ++i) {
+  for (let i = 0; i < fileCount; ++i) {
     const relName = `foo${i}.txt`;
     const absFile = join(absDir, relName);
 
@@ -682,7 +686,7 @@ async function performWriteLockCheckTest(t, fileCount: number) {
     await ioContext.performWriteLockChecks(absDir, Array.from(fileHandles.keys()));
     t.log('Ensure no file is reported as being written to');
     if (fileCount === 0) {
-      t.true(true);
+      t.true(true); // to satisfy t.plan
     }
   } catch (error) {
     if (error instanceof AggregateError) {

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -644,7 +644,7 @@ async function performWriteLockCheckTest(t, fileCount: number) {
   fileHandles.set(noFileHandleFile, null);
 
   const readFileHandleFile: string = 'read-file-handle.txt';
-  const absReadFileHandleFile = join(absDir, noFileHandleFile);
+  const absReadFileHandleFile = join(absDir, readFileHandleFile);
   fse.writeFileSync(absReadFileHandleFile, 'single read-handle is on this file');
   fileHandles.set(readFileHandleFile, fse.createReadStream(absReadFileHandleFile, { flags: 'r' }));
 

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -715,7 +715,7 @@ async function performWriteLockCheckTest(t, fileCount: number) {
   stop = true;
 }
 
-test.only('performWriteLockChecks / 0 file', async (t) => {
+test('performWriteLockChecks / 0 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 0);
   } catch (error) {
@@ -724,7 +724,7 @@ test.only('performWriteLockChecks / 0 file', async (t) => {
   }
 });
 
-test.only('performWriteLockChecks / 1 file', async (t) => {
+test('performWriteLockChecks / 1 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 1);
   } catch (error) {
@@ -733,7 +733,7 @@ test.only('performWriteLockChecks / 1 file', async (t) => {
   }
 });
 
-test.only('performWriteLockChecks / 10 file', async (t) => {
+test('performWriteLockChecks / 10 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 10);
   } catch (error) {
@@ -742,7 +742,7 @@ test.only('performWriteLockChecks / 10 file', async (t) => {
   }
 });
 
-test.only('performWriteLockChecks / 100 file', async (t) => {
+test('performWriteLockChecks / 100 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 100);
   } catch (error) {
@@ -751,7 +751,7 @@ test.only('performWriteLockChecks / 100 file', async (t) => {
   }
 });
 
-test.only('performWriteLockChecks / 1000 file', async (t) => {
+test('performWriteLockChecks / 1000 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 1000);
   } catch (error) {

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../src/path';
 import * as fss from '../src/fs-safe';
 import { DirItem, OSWALK, osWalk } from '../src/io';
+import { IoContext } from '../src/io_context';
 import {
   compareFileHash, getRepoDetails, LOADING_STATE, MB100,
 } from '../src/common';
@@ -611,6 +612,137 @@ test('fss.writeSafeFile test', async (t) => {
     await fss.writeSafeFile(tmpFile, 'Foo2');
     t.true(fse.pathExistsSync(tmpFile));
     t.is(fse.readFileSync(tmpFile).toString(), 'Foo2');
+  } catch (error) {
+    console.error(error);
+    t.fail(error.message);
+  }
+});
+
+async function sleep(delay) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, delay);
+  });
+}
+
+async function performWriteLockCheckTest(t, fileCount: number) {
+  t.pass(fileCount ?? 1);
+
+  const tmp = join(process.cwd(), 'tmp');
+  fse.ensureDirSync(tmp);
+
+  const absDir = fse.mkdtempSync(join(tmp, 'snowtrack-'));
+
+  const fileHandles = new Map<string, fse.WriteStream | fse.ReadStream | null>();
+
+  const noFileHandleFile: string = 'no-file-handle.txt';
+  const absNoFileHandleFilePath = join(absDir, noFileHandleFile);
+  fse.writeFileSync(absNoFileHandleFilePath, 'no-file handle is on this file');
+  fileHandles.set(noFileHandleFile, null);
+
+  const readFileHandleFile: string = 'read-file-handle.txt';
+  const absReadFileHandleFile = join(absDir, noFileHandleFile);
+  fse.writeFileSync(absReadFileHandleFile, 'single read-handle is on this file');
+  fileHandles.set(readFileHandleFile, fse.createReadStream(absReadFileHandleFile, { flags: 'r' }));
+
+  for (let i = 0; i < fileCount + 10; ++i) {
+    const relName = `foo${i}.txt`;
+    const absFile = join(absDir, relName);
+
+    fileHandles.set(relName, fse.createWriteStream(absFile, { flags: 'w' }));
+  }
+
+  let stop = false;
+
+  function parallelWrite() {
+    setTimeout(() => {
+      if (stop) {
+        t.log('Stop parallel writes');
+      } else {
+        parallelWrite();
+      }
+    });
+
+    fileHandles.forEach((fh: fse.ReadStream | fse.WriteStream) => {
+      if (fh instanceof fse.WriteStream) {
+        fh.write('123456789abcdefghijklmnopqrstuvwxyz\n');
+      }
+    });
+  }
+
+  parallelWrite();
+
+  await sleep(500); // just to ensure on GitHub runners that all files were written to
+
+  const ioContext = new IoContext();
+  try {
+    await ioContext.performWriteLockChecks(absDir, Array.from(fileHandles.keys()));
+    t.log('Ensure no file is reported as being written to');
+    if (fileCount === 0) {
+      t.true(true);
+    }
+  } catch (error) {
+    const errorMessages: string[] = error.errors.map((e) => e.message);
+
+    let i = 0;
+    fileHandles.forEach((fh: fse.ReadStream | fse.WriteStream | null, path: string) => {
+      if (fh instanceof fse.WriteStream) {
+        if (i === 15) {
+          t.log(`${fileCount - i} more to go...`);
+        } else if (i < 15) {
+          t.log(`Check if ${path} is detected as being written by another process`);
+        }
+        t.true(errorMessages[i++].includes(`File '${path}' is written by`));
+      } else if (!fh || fh instanceof fse.ReadStream) {
+        t.log(`Ensure that ${path} is not being detected as being written by another process`);
+        t.false(errorMessages.includes(`File ${path} is written by`));
+      }
+    });
+  }
+
+  stop = true;
+}
+
+test.only('performWriteLockChecks / 0 file', async (t) => {
+  try {
+    await performWriteLockCheckTest(t, 0);
+  } catch (error) {
+    console.error(error);
+    t.fail(error.message);
+  }
+});
+
+test.only('performWriteLockChecks / 1 file', async (t) => {
+  try {
+    await performWriteLockCheckTest(t, 1);
+  } catch (error) {
+    console.error(error);
+    t.fail(error.message);
+  }
+});
+
+test.only('performWriteLockChecks / 10 file', async (t) => {
+  try {
+    await performWriteLockCheckTest(t, 10);
+  } catch (error) {
+    console.error(error);
+    t.fail(error.message);
+  }
+});
+
+test.only('performWriteLockChecks / 100 file', async (t) => {
+  try {
+    await performWriteLockCheckTest(t, 100);
+  } catch (error) {
+    console.error(error);
+    t.fail(error.message);
+  }
+});
+
+test.only('performWriteLockChecks / 1000 file', async (t) => {
+  try {
+    await performWriteLockCheckTest(t, 1000);
   } catch (error) {
     console.error(error);
     t.fail(error.message);

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -5,7 +5,7 @@ import * as unzipper from 'unzipper';
 import test from 'ava';
 
 import {
-  join, relative, dirname, normalize, normalizeExt, sep,
+  join, dirname, normalize, normalizeExt, sep,
 } from '../src/path';
 import * as fss from '../src/fs-safe';
 import { DirItem, OSWALK, osWalk } from '../src/io';
@@ -74,10 +74,10 @@ function getUniquePaths(dirSet: string[]): string[] {
 test('proper normalize', async (t) => {
   let error: any;
 
-  error = await t.throwsAsync(async () => normalize(undefined));
+  error = t.throws(() => normalize(undefined));
   t.is(error.code, 'ERR_INVALID_ARG_TYPE', 'no error expected');
 
-  error = await t.throwsAsync(async () => normalize(null));
+  error = t.throws(() => normalize(null));
   t.is(error.code, 'ERR_INVALID_ARG_TYPE', 'no error expected');
 
   t.is(normalize(''), '');
@@ -321,7 +321,7 @@ test('osWalk test#5', async (t) => {
   }
 });
 
-async function testGitZip(t, zipname: string): Promise<string> {
+function testGitZip(t, zipname: string): Promise<string> {
   const snowtrack: string = join(os.tmpdir(), 'foo');
 
   let tmpDir: string;
@@ -334,7 +334,7 @@ async function testGitZip(t, zipname: string): Promise<string> {
       t.log(`Unzip: ${zipname}`);
       return unzipper.Open.buffer(fse.readFileSync(gitanddstPath));
     })
-    .then((d) => d.extract({ path: normalizeExt(tmpDir, sep), concurrency: 5 }))
+    .then((d) => d.extract({ path: normalizeExt(tmpDir).replace('/', sep), concurrency: 5 }))
     .then(() =>
       // if tmpDir starts with /var/ we replace it with /private/var because
       // it is a symlink on macOS.
@@ -347,7 +347,7 @@ test('getRepoDetails (no git directory nor snowtrack)', async (t) => {
   t.plan(8);
 
   let tmpDir: string;
-  async function runTest(filepath: string = '', errorMessage?: string) {
+  function runTest(filepath: string = '', errorMessage?: string) {
     if (filepath) t.log(LOG_FILE, filepath);
     else t.log(LOG_DIRECTORY);
 

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -8,7 +8,7 @@ import { COMMIT_ORDER, REFERENCE_TYPE, Repository } from '../src/repository';
 import { Reference } from '../src/reference';
 import { DirItem, OSWALK, osWalk } from '../src/io';
 
-function getSnowexec(t): string {
+function getSnowexec(): string {
   switch (process.platform) {
     case 'darwin':
       return join(__dirname, '..', './bin/snow');
@@ -25,7 +25,7 @@ function getSnowexec(t): string {
 test('snow add/commit/log', async (t) => {
   t.timeout(180000);
 
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   await exec(t, snow, ['init', basename(snowWorkdir)], { cwd: dirname(snowWorkdir) });
@@ -48,7 +48,7 @@ test.only('snow switch', async (t) => {
   t.timeout(180000);
 
   let out: string | void;
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   // Create branch succesfully
@@ -147,7 +147,7 @@ test.only('snow switch', async (t) => {
 
 test('snow checkout', async (t) => {
   let out: string | void;
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   // Create branch succesfully
@@ -256,7 +256,7 @@ test('snow branch foo-branch', async (t) => {
 
   let out: string | void;
   let error: any;
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   // Create branch succesfully
@@ -324,7 +324,7 @@ test('snow branch foo-branch', async (t) => {
 test('snow add .', async (t) => {
   t.timeout(180000);
 
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const subdir = join(snowWorkdir, 'subdir');
 
@@ -346,7 +346,7 @@ test('snow add .', async (t) => {
 });
 
 test('snow add *', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const subdir = join(snowWorkdir, 'subdir');
 
@@ -371,7 +371,7 @@ test('snow add *', async (t) => {
  * This test ensures that foo.txt is not added to the staging area because cwd is the subdirectory
  */
 test('snow add foo.txt', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const subdir = join(snowWorkdir, 'subdir');
 
@@ -393,7 +393,7 @@ test('snow add foo.txt', async (t) => {
 });
 
 test('snow add bar.txt', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const subdir = join(snowWorkdir, 'subdir');
 
@@ -415,7 +415,7 @@ test('snow add bar.txt', async (t) => {
 });
 
 test('snow rm foo.txt', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const subdir = join(snowWorkdir, 'subdir');
 
@@ -442,7 +442,7 @@ test('snow rm foo.txt', async (t) => {
 });
 
 test('snow rm subdir', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const subdir = join(snowWorkdir, 'subdir');
 
@@ -469,7 +469,7 @@ test('snow rm subdir', async (t) => {
 });
 
 test('snow rm subdir/bar.txt', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const subdir = join(snowWorkdir, 'subdir');
 
@@ -496,7 +496,7 @@ test('snow rm subdir/bar.txt', async (t) => {
 });
 
 test('snow rm file-does-not-exist', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const subdir = join(snowWorkdir, 'subdir');
 
@@ -522,7 +522,7 @@ test('snow rm file-does-not-exist', async (t) => {
 });
 
 test('Commit User Data --- STORE AND LOAD IDENTICAL', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   const uData: any = { str_key: 'str_value', int_key: 3 };
@@ -559,7 +559,7 @@ test('Commit User Data --- STORE AND LOAD IDENTICAL', async (t) => {
 });
 
 test('Commit User Data --- FAIL INVALID INPUT', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   await exec(t, snow, ['init', basename(snowWorkdir)], { cwd: dirname(snowWorkdir) });
@@ -573,7 +573,7 @@ test('Commit User Data --- FAIL INVALID INPUT', async (t) => {
 });
 
 test('Commit Tags --- STORE AND LOAD IDENTICAL', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   const tag1 = 'FirstTag';
@@ -595,7 +595,7 @@ test('Commit Tags --- STORE AND LOAD IDENTICAL', async (t) => {
 });
 
 test('Commit Tags --- SPECIAL SYMBOLS INPUT', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   const tag1 = '[]}';
@@ -616,7 +616,7 @@ test('Commit Tags --- SPECIAL SYMBOLS INPUT', async (t) => {
 });
 
 test('Commit Tags --- EMPTY INPUT', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   await exec(t, snow, ['init', basename(snowWorkdir)], { cwd: dirname(snowWorkdir) });
@@ -630,7 +630,7 @@ test('Commit Tags --- EMPTY INPUT', async (t) => {
 });
 
 test('Branch User Data --- STORE AND LOAD IDENTICAL', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   const uData: any = { str_key: 'str_value', int_key: 3 };
@@ -668,7 +668,7 @@ test('Branch User Data --- STORE AND LOAD IDENTICAL', async (t) => {
 });
 
 test('Branch User Data --- FAIL INVALID INPUT', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
   const branchName = 'u-data-test';
 
@@ -684,7 +684,7 @@ test('Branch User Data --- FAIL INVALID INPUT', async (t) => {
 });
 
 test('Multi-Index -- CREATE 2 INDEXES, COMMIT SEQUENTIALLY', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   await exec(t, snow, ['init', basename(snowWorkdir)], { cwd: dirname(snowWorkdir) });
@@ -743,7 +743,7 @@ test('Multi-Index -- CREATE 2 INDEXES, COMMIT SEQUENTIALLY', async (t) => {
 test('Multi-Index -- FAIL INVALID INPUT TEST 1', async (t) => {
   t.timeout(180000);
 
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();
 
   await exec(t, snow, ['init', basename(snowWorkdir)], { cwd: dirname(snowWorkdir) });
@@ -759,7 +759,7 @@ test('Multi-Index -- FAIL INVALID INPUT TEST 1', async (t) => {
 });
 
 test('driveinfo test', async (t) => {
-  const snow: string = getSnowexec(t);
+  const snow: string = getSnowexec();
 
   const out1 = await exec(t, snow, ['driveinfo'], {}, EXEC_OPTIONS.RETURN_STDOUT) as string;
 

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -44,7 +44,7 @@ test('snow add/commit/log', async (t) => {
   t.is(true, true);
 });
 
-test('snow switch', async (t) => {
+test.only('snow switch', async (t) => {
   t.timeout(180000);
 
   let out: string | void;

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -44,7 +44,7 @@ test('snow add/commit/log', async (t) => {
   t.is(true, true);
 });
 
-test.only('snow switch', async (t) => {
+test('snow switch', async (t) => {
   t.timeout(180000);
 
   let out: string | void;

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -76,7 +76,7 @@ export function createRandomFile(dst: string, size: number): Promise<{filepath: 
     .then((res: {filehash: string, hashBlocks?: HashBlock[]}) => ({ filepath: dst, filehash: res.filehash, hashBlocks: res.hashBlocks }));
 }
 
-export function getSnowexec(t): string {
+export function getSnowexec(): string {
   switch (process.platform) {
     case 'darwin':
       return join(__dirname, '..', './bin/snow');


### PR DESCRIPTION
### From issue #148

Given a brief overview in #110 the situation needs to be clarified what happens when 1 or more external processes access files that SnowFS wants to access as well.

# Windows

Currently the write-lock check is performed by a file-size comparison and a 500ms timeout in-between the checks to ensure no process is actively writing to the requested files. This test is verified by a unit-test in `1.sys.test.ts`

# MacOS, Linux

The file-handle information are acquired by `lsof` and checked for write-handles. Read-handles are ignored. Both cases are tested in `1.sys.test.ts`
