### PR TITLE
:bug: head printed 'HEAD' instead of commit hash (Closes: #152)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -519,7 +519,7 @@ program
       const headName: string = repo.getHead().getName();
 
       if (opts.output === 'json' || opts.output === 'json-pretty') {
-        const o = { commits, refs, head: headName };
+        const o = { commits, refs, head: repo.getHead().isDetached() ? headHash : headName };
 
         process.stdout.write(JSON.stringify(o, (key, value) => {
           if (value instanceof Commit) {


### PR DESCRIPTION
As described in #152, `snow log` literally returned 'HEAD' instead of the commit-hash