### PR TITLE
:bug: introduce winattr to set hidden attribute on Win (Closes: 156)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "micromatch": "^4.0.2",
     "ts-node": "^9.1.1"
   },
+  "optionalDependencies": {
+    "winattr": "^3.0.0"
+  },
   "devDependencies": {
     "@types/fs-extra": "^9.0.6",
     "@types/lodash": "^4.14.167",

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,7 +1,12 @@
 import * as cp from 'child_process';
 import * as fse from 'fs-extra';
-
 import { normalize } from './path';
+
+let winattr;
+if (process.platform === 'win32') {
+  // eslint-disable-next-line global-require
+  winattr = require('winattr');
+}
 
 export class DirItem {
   /** Absolute path of dir item */
@@ -135,4 +140,24 @@ export function zipFile(src: string, dst: string, opts: {deleteSrc: boolean}): P
       return fse.remove(src);
     }
   });
+}
+
+/**
+ * Hides a given directory or file. If the function failed to hide the item,
+ * the function doesn't throw an exception.
+ *
+ * @param path      Path to file or dir to hide.
+ * @returns
+ */
+export function hideItem(path: string): Promise<void> {
+  if (winattr) {
+    return new Promise<void>((resolve) => {
+      winattr.set(path, { hidden: true }, (error) => {
+        console.log(error);
+        // not being able to hide the directory shouldn't stop us here
+        resolve();
+      });
+    });
+  }
+  return Promise.resolve();
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -11,7 +11,9 @@ import { Commit } from './commit';
 import { FileInfo } from './common';
 import { IgnoreManager } from './ignore';
 import { Index } from './index';
-import { DirItem, OSWALK, osWalk } from './io';
+import {
+  DirItem, hideItem, OSWALK, osWalk,
+} from './io';
 import { IoContext } from './io_context';
 import { Odb } from './odb';
 import { Reference } from './reference';
@@ -1005,7 +1007,7 @@ export class Repository {
         return this.repoOdb.writeHeadReference(this.head);
       })
       .then(() =>
-      // update .snow/refs/XYZ
+        // update .snow/refs/XYZ
         this.repoOdb.writeReference(this.head))
       .then(() => this.repoLog.writeLog(`commit: ${message}`))
       .then(() => commit);
@@ -1130,18 +1132,21 @@ export class Repository {
     }
 
     return fse.ensureDir(workdir)
-      .then(() => {
-        if (commondirOutside) {
-          const snowtrackFile: string = join(workdir, '.snow');
-          return fse.writeFile(snowtrackFile, opts.commondir);
-        }
-      }).then(() => Odb.create(repo, opts))
+      .then(() => Odb.create(repo, opts))
       .then((odb: Odb) => {
         repo.repoOdb = odb;
         repo.options = opts;
         repo.repoWorkDir = workdir;
         repo.repoCommonDir = opts.commondir;
         repo.repoIndexes = [];
+
+        if (commondirOutside) {
+          const snowtrackFile: string = join(workdir, '.snow');
+          return fse.writeFile(snowtrackFile, opts.commondir)
+            .then(() => hideItem(snowtrackFile));
+        }
+        return hideItem(opts.commondir);
+      }).then(() => {
         repo.repoLog = new Log(repo);
         return repo.repoLog.init();
       })


### PR DESCRIPTION
Introduce [winattr](https://github.com/stevenvachon/winattr) to set a file/dir attribute to hide a given item. The module is only loaded on Windows, and skipped on Linux/Darwin.