### PR TITLE
:star: Keep file extensions for files in odb (Closes: 158)

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -19,6 +19,8 @@ export const MB1 = 1000000;
 export class FileInfo {
   hash: string;
 
+  ext: string; // including '.'
+
   stat: {
     size: number,
     atime: number;

--- a/src/io.ts
+++ b/src/io.ts
@@ -4,7 +4,7 @@ import { normalize } from './path';
 
 let winattr;
 if (process.platform === 'win32') {
-  // eslint-disable-next-line global-require
+  // eslint-disable-next-line global-require, import/no-extraneous-dependencies
   winattr = require('winattr');
 }
 

--- a/src/odb.ts
+++ b/src/odb.ts
@@ -2,7 +2,7 @@ import * as crypto from 'crypto';
 import * as fse from 'fs-extra';
 
 import {
-  basename, join, dirname, relative,
+  basename, join, dirname, relative, extname,
 } from './path';
 import {
   DirItem, OSWALK, osWalk, zipFile,
@@ -171,9 +171,9 @@ export class Odb {
     });
   }
 
-  getObjectPath(file: TreeFile): string {
+  getAbsObjectPath(file: TreeFile): string {
     const objects: string = join(this.repo.options.commondir, 'objects');
-    return join(objects, file.hash.substr(0, 2), file.hash.substr(2, 2), file.hash.toString());
+    return join(objects, file.hash.substr(0, 2), file.hash.substr(2, 2), file.hash.toString() + extname(file.path));
   }
 
   writeReference(ref: Reference): Promise<void> {
@@ -236,7 +236,7 @@ export class Odb {
     const tmpFilename: string = crypto.createHash('sha256').update(process.hrtime().toString()).digest('hex');
     const objects: string = join(this.repo.options.commondir, 'objects');
     const tmpDir: string = join(this.repo.options.commondir, 'tmp');
-    const tmpPath: string = join(tmpDir, tmpFilename.toString());
+    const tmpPath: string = join(tmpDir, tmpFilename);
 
     let dstFile: string;
     let filehash: string;
@@ -250,7 +250,7 @@ export class Odb {
       .then((res: {filehash: string, hashBlocks?: HashBlock[]}) => {
         filehash = res.filehash;
         hashBlocks = res.hashBlocks;
-        dstFile = join(objects, filehash.substr(0, 2), filehash.substr(2, 2), filehash.toString());
+        dstFile = join(objects, filehash.substr(0, 2), filehash.substr(2, 2), filehash.toString() + extname(filepath));
         return fse.pathExists(dstFile);
       })
       .then((exists: boolean) => {
@@ -276,6 +276,7 @@ export class Odb {
         .then((stat: fse.Stats) => ({
           file: relative(this.repo.repoWorkDir, filepath),
           fileinfo: {
+            ext: extname(filepath),
             hash: filehash,
             stat: {
               size: stat.size,
@@ -288,8 +289,9 @@ export class Odb {
       .then((res) => this.repo.modified(res));
   }
 
-  readObject(hash: string, dstAbsPath: string, ioContext: IoContext): Promise<void> {
-    const objectFile: string = join(this.repo.options.commondir, 'objects', hash.substr(0, 2), hash.substr(2, 2), hash.toString());
+  readObject(file: TreeFile, dstAbsPath: string, ioContext: IoContext): Promise<void> {
+    const hash: string = file.hash;
+    const objectFile: string = this.getAbsObjectPath(file);
 
     return fse.pathExists(objectFile).then((exists: boolean) => {
       if (!exists) {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -3,7 +3,7 @@
 import * as fse from 'fs-extra';
 import * as crypto from 'crypto';
 import {
-  resolve, join, dirname,
+  resolve, join, dirname, extname,
 } from './path';
 
 import { Log } from './log';
@@ -706,7 +706,7 @@ export class Repository {
             if (status.isFile()) {
               const tfile: TreeEntry = oldFilesMap.get(status.path);
               if (tfile) {
-                tasks.push(() => this.repoOdb.readObject(tfile.hash, dst, ioContext));
+                tasks.push(() => this.repoOdb.readObject(<TreeFile>tfile, dst, ioContext));
               } else {
                 throw new Error("item was detected as deleted but couldn't be found in reference commit");
               }
@@ -735,7 +735,7 @@ export class Repository {
               tasks.push(() => tfile.isFileModified(this).then((res: {file: TreeFile, modified : boolean}) => {
                 if (res.modified) {
                   const dst: string = join(this.repoWorkDir, res.file.path);
-                  return this.repoOdb.readObject(res.file.hash, dst, ioContext);
+                  return this.repoOdb.readObject(res.file, dst, ioContext);
                 }
               }));
             } else {
@@ -942,6 +942,7 @@ export class Repository {
       currentTree.forEach((value: TreeFile) => {
         processedMap.set(value.path, {
           hash: value.hash,
+          ext: extname(value.path),
           stat: {
             size: value.size, atime: 0, mtime: value.mtime, ctime: value.ctime,
           },


### PR DESCRIPTION
This change keeps the extensions for stored files in the object database. More information are available in #158. It also keeps the file extensions alive when files are moved to the trash.