### PR TITLE
:bug: prevent move from failing on Windows (Closes: 163)

### DIFF
--- a/src/odb.ts
+++ b/src/odb.ts
@@ -263,7 +263,18 @@ export class Odb {
           return zipFile(tmpPath, dstFile, { deleteSrc: true });
         }
 
-        return fse.move(tmpPath, dstFile, { overwrite: false });
+        return fse.move(tmpPath, dstFile, { overwrite: false })
+          .catch((error) => {
+            // the error message below is thrown, especially on Windows if
+            // several files that are commited have the same fingerprint hash.
+            // This leads to the same dstFile, and despite 'overwrite:false',
+            // concurrent write operations might make this function fail, so
+            // we can safely ignore it
+            if (!error.message.startsWith('dest already exists')
+                && !error.message.startsWith('EPERM: operation not permitted, rename')) {
+              throw error;
+            }
+          });
       })
       .then(() => {
         if (hashBlocks) {


### PR DESCRIPTION
This bugfix catches specific error messages thrown by `fse.move`, despite the `overwrite: false` argument.