### PR TITLE
:racehorse: speedup ignore handling

### DIFF
--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -46,10 +46,11 @@ export class IgnoreManager {
       });
     }
 
-    ignored(filepath: string): boolean {
-      return nm.match(filepath, this.patterns, {
+    ignoredList(filepaths: string[]): Set<string> {
+      const ignored = nm(filepaths, this.patterns, {
         dot: true, // Match dotfiles
         nocase: true, // a case-insensitive regex for matching files
-      }).length > 0;
+      });
+      return new Set(ignored as string[]);
     }
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -822,7 +822,7 @@ export class Repository {
         walk |= filter & FILTER.INCLUDE_DIRECTORIES ? OSWALK.DIRS : 0;
         return osWalk(this.repoWorkDir, walk);
       })
-      .then((currentFilesInProj: DirItem[]) => {
+      .then((currentItemsInProj: DirItem[]) => {
         const targetCommit: Commit = commit ?? this.getCommitByHead();
         const promises = [];
 
@@ -832,13 +832,15 @@ export class Repository {
         }
 
         // Get all tree entries from HEAD
-        const oldFilesMap: Map<string, TreeEntry> = targetCommit.root.getAllTreeFiles({ entireHierarchy: true, includeDirs: true });
-        const curFilesMap: Map<string, DirItem> = new Map(currentFilesInProj.map((x: DirItem) => [x.relPath, x]));
+        const oldItemsMap: Map<string, TreeEntry> = targetCommit.root.getAllTreeFiles({ entireHierarchy: true, includeDirs: true });
+        const curItemsMap: Map<string, DirItem> = new Map(currentItemsInProj.map((x: DirItem) => [x.relPath, x]));
 
-        const oldFiles: TreeEntry[] = Array.from(oldFilesMap.values());
+        const oldItems: TreeEntry[] = Array.from(oldItemsMap.values());
 
         if (filter & FILTER.INCLUDE_IGNORED) {
-          const ignored: DirItem[] = currentFilesInProj.filter((value) => ignore.ignored(value.relPath));
+          const areIgnored: Set<string> = ignore.ignoredList(currentItemsInProj.map((item) => item.relPath));
+
+          const ignored: DirItem[] = currentItemsInProj.filter((item) => areIgnored.has(item.relPath));
           for (const entry of ignored) {
             if (!entry.isdir || filter & FILTER.INCLUDE_DIRECTORIES) {
               statusResult.set(entry.relPath, new StatusEntry({ path: entry.relPath, status: STATUS.WT_IGNORED }, entry.isdir));
@@ -846,21 +848,39 @@ export class Repository {
           }
         }
 
-        // Files which didn't exist before, but do now
+        // Items which didn't exist before, but do now
         if (filter & FILTER.INCLUDE_UNTRACKED) {
-          const entries: DirItem[] = currentFilesInProj.filter((value) => !oldFilesMap.has(value.relPath) && !ignore.ignored(value.relPath));
-          for (const entry of entries) {
+          // check which items are new and didn't exist in the old commit
+          const itemsStep1: DirItem[] = currentItemsInProj.filter((item) => !oldItemsMap.has(item.relPath));
+
+          /// check which items of the new items are ignored
+          const areIgnored: Set<string> = ignore.ignoredList(itemsStep1.map((item) => item.relPath));
+
+          // get the list of new items which are not ignored
+          const itemsStep2: DirItem[] = itemsStep1.filter((item) => !areIgnored.has(item.relPath));
+
+          for (const entry of itemsStep2) {
             if (!entry.isdir || filter & FILTER.INCLUDE_DIRECTORIES) {
-              statusResult.set(entry.relPath, new StatusEntry({ path: entry.relPath, status: STATUS.WT_NEW }, entry.isdir));
+              statusResult.set(entry.relPath, new StatusEntry({
+                path: entry.relPath,
+                status: STATUS.WT_NEW,
+              }, entry.isdir));
             }
           }
         }
 
-        // Files which existed before but don't anymore
+        // Items which existed before but don't anymore
         if (filter & FILTER.INCLUDE_DELETED) {
-          const entries: TreeEntry[] = oldFiles.filter((value) => !curFilesMap.has(value.path) && !ignore.ignored(value.path));
+          // check which items are deleted now
+          const itemsStep1: TreeEntry[] = oldItems.filter((item) => !curItemsMap.has(item.path));
 
-          for (const entry of entries) {
+          /// check which items of the deleted items are ignored
+          const areIgnored: Set<string> = ignore.ignoredList(itemsStep1.map((item) => item.path));
+
+          // get the list of deleted items which are not ignored
+          const itemsStep2: TreeEntry[] = itemsStep1.filter((item) => !areIgnored.has(item.path));
+
+          for (const entry of itemsStep2) {
             if (!entry.isDirectory() || filter & FILTER.INCLUDE_DIRECTORIES) {
               statusResult.set(entry.path, new StatusEntry({ path: entry.path, status: STATUS.WT_DELETED }, entry.isDirectory()));
             }
@@ -868,22 +888,39 @@ export class Repository {
         }
 
         if (filter & FILTER.INCLUDE_DIRECTORIES) {
-          for (const entry of currentFilesInProj) {
-            if (entry.isdir && !statusResult.has(entry.relPath) && !ignore.ignored(entry.relPath)) {
-              // the status of this directory will later be overwritten in case
-              // the directory contains a file that is modified
-              statusResult.set(entry.relPath, new StatusEntry({ path: entry.relPath, status: 0 }, true));
-            }
+          // check which items are a directory
+          const itemsStep1: DirItem[] = currentItemsInProj.filter((item) => item.isdir && !statusResult.has(item.relPath));
+
+          /// check which items of the directories are ignored
+          const areIgnored: Set<string> = ignore.ignoredList(itemsStep1.map((item) => item.relPath));
+
+          // get the list of directories which are not ignored
+          const itemsStep2: DirItem[] = itemsStep1.filter((item) => !areIgnored.has(item.relPath));
+
+          for (const item of itemsStep2) {
+            // the status of this directory will later be overwritten in case
+            // the directory contains a file that is modified
+            statusResult.set(item.relPath, new StatusEntry({
+              path: item.relPath,
+              status: 0,
+            }, true));
           }
         }
 
-        // Check which files were modified
+        // Check which items were modified
         if (filter & FILTER.INCLUDE_MODIFIED) {
-          const entries: TreeEntry[] = oldFiles.filter((value) => curFilesMap.has(value.path) && !ignore.ignored(value.path));
+          // check which items did exist before and now
+          const itemsStep1: TreeEntry[] = oldItems.filter((item) => curItemsMap.has(item.path));
 
-          for (const existingEntry of entries) {
-            if (existingEntry instanceof TreeFile) {
-              promises.push(existingEntry.isFileModified(this));
+          /// check which items of the still existing items are ignored
+          const areIgnored: Set<string> = ignore.ignoredList(itemsStep1.map((item) => item.path));
+
+          // get the list of items which are not ignored
+          const itemsStep2: TreeEntry[] = itemsStep1.filter((item) => !areIgnored.has(item.path));
+
+          for (const existingItem of itemsStep2) {
+            if (existingItem instanceof TreeFile) {
+              promises.push(existingItem.isFileModified(this));
             }
           }
         }


### PR DESCRIPTION
This change introduces a speedup for `snow status` and `snow add`. Both rely on the ignore handling, which was slow due to the call of `ignore.ignored(file, this.patterns)` for each single file. The module [micromatch](https://github.com/micromatch/micromatch) which is used under the hood, evaluated the regex for each file. Passing over a list of all files in a single shot results in the speed improvements as demonstrated below - same repo as from the initial bug report (> 40000 files):

```
$ ls -lsa | wc -l
40003

$ time /c/Users/sebastian/Documents/git/SnowFS/dist/out-tsc/snow.exe status > /c/Users/sebastian/Desktop/output.txt

real    0m2.142s
user    0m0.015s
sys     0m0.000s

$ time /c/Users/sebastian/Documents/git/SnowFS/dist/out-tsc/snow.exe add .

real    0m31.213s
user    0m0.015s
sys     0m0.000s

$ time /c/Users/sebastian/Documents/git/SnowFS/dist/out-tsc/snow.exe status > /c/Users/sebastian/Desktop/output.txt

real    0m2.502s
user    0m0.015s
sys     0m0.000s
```

In comparison to the results from the bug report:

| | Before | After |
| :--- | :----: | ---: |
| snow status | 7.0.48s | 2.142s |
| snow add | 48.148s | 31.213s|

