### PR TITLE
Add stats to (Tree/Status)Entry/DirItem, add access test + restore mtime

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -539,9 +539,9 @@ program
             return {
               path: value.path,
               hash: value.hash,
-              ctime: value.ctime / 1000.0,
-              mtime: value.mtime / 1000.0,
-              size: value.size,
+              ctime: value.stats.ctimeMs,
+              mtime: value.stats.mtimeMs,
+              size: value.stats.size,
             };
           }
           if (value instanceof Reference) {
@@ -615,7 +615,7 @@ program
               if (value.isDirectory()) {
                 process.stdout.write(`      [${value.hash}] ${value.path}\n`);
               } else if (value instanceof TreeFile) {
-                process.stdout.write(`      [${value.hash}] ${value.path} (${value.size}B)\n`);
+                process.stdout.write(`      [${value.hash}] ${value.path} (${value.stats.size}B)\n`);
               }
             });
             if (files.size > 0) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -12,6 +12,14 @@ export const MB10 = 10000000;
 export const MB2 = 2000000;
 export const MB1 = 1000000;
 
+export class StatsSubset {
+  size: number;
+
+  ctimeMs: number;
+
+  mtimeMs: number;
+}
+
 /**
  * A commonly used class which contains a hash and
  * file stats of a given file
@@ -21,12 +29,7 @@ export class FileInfo {
 
   ext: string; // including '.'
 
-  stat: {
-    size: number,
-    atime: number;
-    mtime: number;
-    ctime: number;
-  }
+  stat: StatsSubset;
 }
 
 /**


### PR DESCRIPTION
This PR introduces several optimizations and changes

1) Stats added to `TreeDir`, `TreeFile`, `StatusEntry` and `DirItem`. When a `TreeEntry` is restored, the `mtime` is set to ensure they match exactly the `mtime` from the file in the commit.
2) `checkout` and `status` can now choose between 3 detection modes
   - only size and mktime
   - size and mtime for files > 20MB otherwise filehash
   - size and hash for all files
3) On `checkout`, the file is now tested for writability, to return a proper error message, if a file permission would prevent the checkout from succeeding

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)