### PR TITLE
fix warnings and cleanup error messages

### DIFF
--- a/benchmark/snowfs-vs-git.ts
+++ b/benchmark/snowfs-vs-git.ts
@@ -62,7 +62,7 @@ async function createRandomBuffer() {
 async function createFile(dst: string, size: number, t = console) {
   const stream = fse.createWriteStream(dst, { flags: 'w' });
 
-  const delimiter: string = `Create ${basename(dst)} file of ${size} bytes`;
+  const delimiter = `Create ${basename(dst)} file of ${size} bytes`;
   let t0 = new Date().getTime();
   let curSize: number = 0;
 

--- a/main.ts
+++ b/main.ts
@@ -20,6 +20,8 @@ const chalk = require('chalk');
 const drivelist = require('drivelist');
 const AggregateError = require('es-aggregate-error');
 
+const versionString = '0.9.1';
+
 function fileMatch(relFilepath: string, relCwd: string, pathPattern: string): boolean {
   return pathPattern === '*' || (pathPattern === '.' && relFilepath.startsWith(relCwd)) || pathPattern === relative(relCwd, relFilepath);
 }
@@ -114,7 +116,7 @@ async function parseOptions(opts: any) {
 }
 
 program
-  .version('0.9.1')
+  .version(versionString)
   .description('SnowFS - a fast, scalable version control file storage for graphic files.');
 
 program
@@ -124,7 +126,13 @@ program
   .action(async (path: string, commondir?: string, opts?: any) => {
     const repoPath: string = path ?? '.';
     try {
-      await Repository.initExt(repoPath, { commondir });
+      await Repository.initExt(repoPath, {
+        commondir,
+        additionalConfig: {
+          creator: 'snowfs-cli',
+          version: versionString,
+        },
+      });
     } catch (error) {
       if (opts.debug) {
         throw error;

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -73,14 +73,14 @@ export class Commit {
   /**
    * Add custom data to the commit object.
    */
-  addData(key: string, value: any) {
+  addData(key: string, value: any): void {
     this.userData[key] = value;
   }
 
   /**
    * Add custom tag to the commit object.
    */
-  addTag(tag: string) {
+  addTag(tag: string): void {
     if (tag.length === 0) {
       return;
     }

--- a/src/odb.ts
+++ b/src/odb.ts
@@ -65,7 +65,13 @@ export class Odb {
       .then(() => fse.ensureDir(join(options.commondir, 'refs')))
       .then(() => {
         odb.config = { ...defaultConfig };
-        return fse.writeFile(join(options.commondir, 'config'), JSON.stringify(defaultConfig));
+
+        let config = { ...defaultConfig };
+        if (options.additionalConfig) {
+          config = Object.assign(config, { additionalConfig: options.additionalConfig });
+        }
+
+        return fse.writeFile(join(options.commondir, 'config'), JSON.stringify(config));
       })
       .then(() => odb);
   }
@@ -165,10 +171,12 @@ export class Odb {
 
   readHeadReference(): Promise<string | null> {
     const refsDir: string = this.repo.options.commondir;
-    return fse.readFile(join(refsDir, 'HEAD')).then((buf: Buffer) => buf.toString()).catch((error) => {
-      console.log('No HEAD found');
-      return null;
-    });
+    return fse.readFile(join(refsDir, 'HEAD'))
+      .then((buf: Buffer) => buf.toString())
+      .catch((error) => {
+        console.log('No HEAD found');
+        return null;
+      });
   }
 
   getAbsObjectPath(file: TreeFile): string {

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -31,7 +31,7 @@ export class Reference {
       return this.refName;
     }
 
-    setName(name: string) {
+    setName(name: string): void {
       this.refName = name;
     }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -49,6 +49,8 @@ export class RepositoryInitOptions {
 
   compress?: boolean;
 
+  additionalConfig?: any;
+
   /**
    * @param commondir Path outside the repository where the versions are stored
    * @param compress true or false if the repository shall be compressed. Still needs work.
@@ -817,11 +819,11 @@ export class Repository {
                 }
               });
               /// ... the delete operation below.
-              tasks.push(() => IoContext.putToTrash(join(this.workdir(), candidate.path)));
+              tasks.push(() => IoContext.putToTrash(join(this.workdir(), candidate.path), candidate.path));
             }
           } else {
             relPathChecks.push(candidate.path);
-            tasks.push(() => IoContext.putToTrash(join(this.workdir(), candidate.path)));
+            tasks.push(() => IoContext.putToTrash(join(this.workdir(), candidate.path), candidate.path));
           }
         });
 

--- a/src/treedir.ts
+++ b/src/treedir.ts
@@ -135,7 +135,7 @@ export class TreeDir extends TreeEntry {
     super('', path, stats);
   }
 
-  static createRootTree() {
+  static createRootTree(): TreeDir {
     return new TreeDir('', { size: 0, ctimeMs: 0, mtimeMs: 0 });
   }
 
@@ -216,7 +216,6 @@ export class TreeDir extends TreeEntry {
       }
     }
 
-    const tree: TreeEntry| null = null;
     // TODO: (Seb) return faster if found
     privateDelete(this, (entry: TreeEntry): boolean => {
       if (entry.path === relativePath) {
@@ -228,7 +227,7 @@ export class TreeDir extends TreeEntry {
   static walk(
     tree: TreeDir,
     cb: (entry: TreeDir | TreeFile, index: number, length: number) => void,
-  ) {
+  ): void {
     let i = 0;
     for (const entry of tree.children) {
       cb(<TreeFile>entry, i, tree.children.length);

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -37,8 +37,8 @@ const exampleFiles = [
   join('y', '1', '2', 'file6'),
 ];
 
-const LOG_DIRECTORY: string = 'Check getRepoDetails(..) with directory path';
-const LOG_FILE: string = 'Check getRepoDetails(..) with  filepath:';
+const LOG_DIRECTORY = 'Check getRepoDetails(..) with directory path';
+const LOG_FILE = 'Check getRepoDetails(..) with  filepath:';
 
 async function createDirs(t, tmpDir: string, dirs: string[]) {
   if (dirs.length === 0) {
@@ -62,7 +62,7 @@ function getUniquePaths(dirSet: string[]): string[] {
 
   const visitedPaths: Set<string> = new Set();
   for (const dir of dirSet) {
-    let sumPath: string = '';
+    let sumPath = '';
     for (const p of dir.split('/')) {
       sumPath = join(sumPath, p);
       visitedPaths.add(sumPath);
@@ -151,7 +151,7 @@ test('osWalk test#2a', async (t) => {
     /// //////////////////////////////////////////////////////////////////////////
     t.log('Create a set of directories and files and verify with osWalk(returnDirs=true, returnFiles=true)');
     /// //////////////////////////////////////////////////////////////////////////
-    const tmpDir: string = `${await fse.mkdtemp(join(os.tmpdir(), 'snowtrack-'))}/`;
+    const tmpDir = `${await fse.mkdtemp(join(os.tmpdir(), 'snowtrack-'))}/`;
     await createDirs(t, tmpDir, exampleDirs);
     for (let file of exampleFiles) {
       file = join(tmpDir, file);
@@ -347,7 +347,7 @@ test('getRepoDetails (no git directory nor snowtrack)', async (t) => {
   t.plan(8);
 
   let tmpDir: string;
-  function runTest(filepath: string = '', errorMessage?: string) {
+  function runTest(filepath = '', errorMessage?: string) {
     if (filepath) t.log(LOG_FILE, filepath);
     else t.log(LOG_DIRECTORY);
 
@@ -410,7 +410,7 @@ test('getRepoDetails (.git)', async (t) => {
   t.plan(4);
 
   let tmpDir: string;
-  async function runTest(filepath: string = '') {
+  async function runTest(filepath = '') {
     if (filepath) t.log(LOG_FILE, filepath);
     else t.log(LOG_DIRECTORY);
 
@@ -456,7 +456,7 @@ test('getRepoDetails (.git and .snow)', async (t) => {
   t.plan(8);
 
   let tmpDir: string;
-  async function runTest(filepath: string = '') {
+  async function runTest(filepath = '') {
     if (filepath) t.log(LOG_FILE, filepath);
     else t.log(LOG_DIRECTORY);
 
@@ -642,12 +642,12 @@ async function performWriteLockCheckTest(t, fileCount: number) {
 
   const fileHandles = new Map<string, fse.WriteStream | fse.ReadStream | null>();
 
-  const noFileHandleFile: string = 'no-file-handle.txt';
+  const noFileHandleFile = 'no-file-handle.txt';
   const absNoFileHandleFilePath = join(absDir, noFileHandleFile);
   fse.writeFileSync(absNoFileHandleFilePath, 'no-file handle is on this file');
   fileHandles.set(noFileHandleFile, null);
 
-  const readFileHandleFile: string = 'read-file-handle.txt';
+  const readFileHandleFile = 'read-file-handle.txt';
   const absReadFileHandleFile = join(absDir, readFileHandleFile);
   fse.writeFileSync(absReadFileHandleFile, 'single read-handle is on this file');
   fileHandles.set(readFileHandleFile, fse.createReadStream(absReadFileHandleFile, { flags: 'r' }));

--- a/test/6.ignore.ts
+++ b/test/6.ignore.ts
@@ -1,7 +1,5 @@
 import test from 'ava';
 
-import * as crypto from 'crypto';
-import * as os from 'os';
 import * as fse from 'fs-extra';
 
 import { join } from '../src/path';

--- a/test/9.cli.ts
+++ b/test/9.cli.ts
@@ -64,7 +64,7 @@ test('snow switch', async (t) => {
 
     // eslint-disable-next-line no-await-in-loop
     out = await exec(t, snow, ['branch', `branch-${i}`], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
-    t.true((out as String).includes(`A branch 'branch-${i}' got created.`));
+    t.true((out as string).includes(`A branch 'branch-${i}' got created.`));
   }
 
   await exec(t, snow, ['log', '--verbose'], { cwd: snowWorkdir });
@@ -163,7 +163,7 @@ test('snow checkout', async (t) => {
 
     // eslint-disable-next-line no-await-in-loop
     out = await exec(t, snow, ['branch', `branch-${i}`], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
-    t.true((out as String).includes(`A branch 'branch-${i}' got created.`));
+    t.true((out as string).includes(`A branch 'branch-${i}' got created.`));
   }
 
   await exec(t, snow, ['log', '--verbose'], { cwd: snowWorkdir });
@@ -275,7 +275,7 @@ test('snow branch foo-branch', async (t) => {
 
   // snow branch foo-branch
   out = await exec(t, snow, ['branch', 'foo-branch'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
-  t.true((out as String).includes("A branch 'foo-branch' got created."));
+  t.true((out as string).includes("A branch 'foo-branch' got created."));
 
   // the hash of 'foo-branch' must match the hash
   const repoAfter = await Repository.open(snowWorkdir);
@@ -289,7 +289,7 @@ test('snow branch foo-branch', async (t) => {
   // Create a branch with a different starting point
   // snow branch bar-branch 768FF3AA8273DFEB81E7A111572C823EA0850499
   out = await exec(t, snow, ['branch', 'bar-branch', firstCommit.hash], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
-  t.true((out as String).includes("A branch 'bar-branch' got created."));
+  t.true((out as string).includes("A branch 'bar-branch' got created."));
 
   // verify the target() and start() point are equal (in this case the
   // start-point and target are still the same since the branch didn't move forward)
@@ -305,9 +305,9 @@ test('snow branch foo-branch', async (t) => {
 
   // Delete foo-branch and bar branch
   out = await exec(t, snow, ['branch', '--delete', 'foo-branch'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
-  t.true((out as String).includes(`Deleted branch 'foo-branch' (was ${fooBranch.target()})`));
+  t.true((out as string).includes(`Deleted branch 'foo-branch' (was ${fooBranch.target()})`));
   out = await exec(t, snow, ['branch', '--delete', 'bar-branch'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
-  t.true((out as String).includes(`Deleted branch 'bar-branch' (was ${barBranch.target()})`));
+  t.true((out as string).includes(`Deleted branch 'bar-branch' (was ${barBranch.target()})`));
 
   // Try to delete the HEAD branch which must fail
   error = await t.throwsAsync(async () =>
@@ -698,10 +698,10 @@ test('Multi-Index -- CREATE 2 INDEXES, COMMIT SEQUENTIALLY', async (t) => {
   const outAddA = await exec(t, snow, ['add', 'a.txt', '--index', 'create'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
   const outAddB = await exec(t, snow, ['add', 'b.txt', '--index', 'create'], { cwd: snowWorkdir }, EXEC_OPTIONS.RETURN_STDOUT);
 
-  const indexAMatch = (outAddA as string).match(/Created new index:\s\[(\w*)\]/);
+  const indexAMatch = /Created new index:\s\[(\w*)\]/.exec(outAddA as string);
   t.true(Boolean(indexAMatch));
 
-  const indexBMatch = (outAddB as string).match(/Created new index:\s\[(\w*)\]/);
+  const indexBMatch = /Created new index:\s\[(\w*)\]/.exec(outAddB as string);
   t.true(Boolean(indexBMatch));
 
   t.log('Write dontcommit-c.txt'); // dummy file just to ensure file is not commited

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -50,7 +50,7 @@ export function rmDirRecursive(dir: string): Promise<void> {
   });
 }
 
-export function createRandomString(length: number) {
+export function createRandomString(length: number): string {
   let result = '';
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   const charactersLength = characters.length;
@@ -93,7 +93,7 @@ export function exec(t, command: string, args?: string[], opts?: {cwd?: string},
 
   const p0 = spawn(command, args ?? [], { cwd: opts?.cwd ?? '.', env: Object.assign(process.env, { SUPPRESS_BANNER: 'true' }) });
   return new Promise((resolve, reject) => {
-    let std: string = '';
+    let std = '';
     if (stdiopts & EXEC_OPTIONS.WRITE_STDIN) {
       p0.stdin.write(`${stdin}\n`);
       p0.stdin.end(); /// this call seems necessary, at least with plain node.js executable


### PR DESCRIPTION
Unspecific cleanup of changes, and `putToTrash` now prints the relative path to make potential error messages shorter