### PR TITLE
Bugfix/issue 171

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   isAbsolute, join, relative, basename,
 } from './path';
 import * as fss from './fs-safe';
-import { IoContext } from './io_context';
+import { IoContext, TEST_IF } from './io_context';
 import { Odb } from './odb';
 import { Repository } from './repository';
 import { DirItem, OSWALK, osWalk } from './io';
@@ -242,7 +242,7 @@ export class Index {
         if (flags & WRITE.SKIP_FILELOCK_CHECKS) {
           return Promise.resolve();
         }
-        return ioContext.performWriteLockChecks(this.repo.workdir(), unprocessedRelItems);
+        return ioContext.performFileAccessCheck(this.repo.workdir(), unprocessedRelItems, TEST_IF.FILE_CAN_BE_READ_FROM);
       }).then(() => {
         return PromisePool
           .withConcurrency(32)

--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -40,6 +40,11 @@ export class Drive {
   }
 }
 
+export enum TEST_IF {
+  FILE_CAN_BE_READ_FROM = 1,
+  FILE_CAN_BE_WRITTEN_TO = 2
+}
+
 export namespace unix {
 
 /**
@@ -425,20 +430,21 @@ export class IoContext {
   }
 
   /**
-   * Check if the given filepaths are write-locked by another process.
+   * Check if the given filepaths are accessibled by another process.
    * For more information, or to add comments visit https://github.com/Snowtrack/SnowFS/discussions/110
    *
    * @param dir               The root directory path to check
    * @param relPaths          Relative file paths inside the given directory.
+   * @param testIf	      Request which access test should be applied on the tests.
    * @throws {AggregateError} Aggregated error of StacklessError
    */
-  performWriteLockChecks(dir: string, relPaths: string[]): Promise<void> {
+  performFileAccessCheck(dir: string, relPaths: string[], testIf: TEST_IF): Promise<void> {
     function checkAccess(absPaths: string[]) {
       const promises = [];
 
       for (const absPath of absPaths) {
         promises.push(new Promise<void>((resolve, reject) => {
-          fse.access(absPath, fse.constants.W_OK, (error) => {
+          fse.access(absPath, testIf === TEST_IF.FILE_CAN_BE_READ_FROM ? fse.constants.R_OK : fse.constants.W_OK, (error) => {
             if (error) {
               reject(error);
             } else {

--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -435,7 +435,7 @@ export class IoContext {
    *
    * @param dir               The root directory path to check
    * @param relPaths          Relative file paths inside the given directory.
-   * @param testIf	      Request which access test should be applied on the tests.
+   * @param testIf            Request which access test should be applied on the tests.
    * @throws {AggregateError} Aggregated error of StacklessError
    */
   performFileAccessCheck(dir: string, relPaths: string[], testIf: TEST_IF): Promise<void> {

--- a/src/odb.ts
+++ b/src/odb.ts
@@ -323,7 +323,7 @@ export class Odb {
       }).then(() => {
         return new Promise<void>((resolve, reject) => {
           // restore mtimes
-          fse.utimes(dstAbsPath, new Date(), new Date(file.stats.mtimeMs), (error) => {
+          fse.utimes(dstAbsPath, new Date(file.stats.mtimeMs), new Date(file.stats.mtimeMs), (error) => {
             if (error) {
               reject(error);
             } else {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -14,7 +14,7 @@ import { Index } from './index';
 import {
   DirItem, hideItem, OSWALK, osWalk,
 } from './io';
-import { IoContext } from './io_context';
+import { IoContext, TEST_IF } from './io_context';
 import { Odb } from './odb';
 import { Reference } from './reference';
 import {
@@ -827,7 +827,7 @@ export class Repository {
           }
         });
 
-        return ioContext.performWriteLockChecks(this.workdir(), relPathChecks);
+        return ioContext.performFileAccessCheck(this.workdir(), relPathChecks, TEST_IF.FILE_CAN_BE_WRITTEN_TO);
       })
       .then(() => {
         return PromisePool

--- a/src/treedir.ts
+++ b/src/treedir.ts
@@ -97,7 +97,13 @@ export class TreeFile extends TreeEntry {
         return { file: this, modified: true, newStats };
       }
 
-      if (Math.floor(this.stats.mtimeMs) !== Math.floor(newStats.mtimeMs)) {
+      // When a commit is checked out, 'mtime' of restored items is set by fse.utimes.
+      // The fractional part (microseconds) of mtime comes from JSON and might be
+      // clamped (rounding errors). It's also not guaranteed that all filesystems support
+      // microseconds. That's why all items are identified if the mtime from the commit
+      // and the mtime from the file on disk is greater than 1ms, everything below is
+      // considered equal.
+      if (Math.abs(this.stats.mtimeMs - newStats.mtimeMs) >= 1.0) {
         switch (detectionMode) {
           case DETECTIONMODE.ONLY_SIZE_AND_MKTIME:
             return { file: this, modified: true, newStats };

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../src/path';
 import * as fss from '../src/fs-safe';
 import { DirItem, OSWALK, osWalk } from '../src/io';
-import { IoContext } from '../src/io_context';
+import { IoContext, TEST_IF } from '../src/io_context';
 import {
   compareFileHash, getRepoDetails, LOADING_STATE, MB100,
 } from '../src/common';
@@ -683,7 +683,7 @@ async function performWriteLockCheckTest(t, fileCount: number) {
 
   const ioContext = new IoContext();
   try {
-    await ioContext.performWriteLockChecks(absDir, Array.from(fileHandles.keys()));
+    await ioContext.performFileAccessCheck(absDir, Array.from(fileHandles.keys()), TEST_IF.FILE_CAN_BE_READ_FROM);
     t.log('Ensure no file is reported as being written to');
     if (fileCount === 0) {
       t.true(true); // to satisfy t.plan
@@ -715,7 +715,7 @@ async function performWriteLockCheckTest(t, fileCount: number) {
   stop = true;
 }
 
-test('performWriteLockChecks / 0 file', async (t) => {
+test('performFileAccessCheck / 0 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 0);
   } catch (error) {
@@ -724,7 +724,7 @@ test('performWriteLockChecks / 0 file', async (t) => {
   }
 });
 
-test('performWriteLockChecks / 1 file', async (t) => {
+test('performFileAccessCheck / 1 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 1);
   } catch (error) {
@@ -733,7 +733,7 @@ test('performWriteLockChecks / 1 file', async (t) => {
   }
 });
 
-test('performWriteLockChecks / 10 file', async (t) => {
+test('performFileAccessCheck / 10 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 10);
   } catch (error) {
@@ -742,7 +742,7 @@ test('performWriteLockChecks / 10 file', async (t) => {
   }
 });
 
-test('performWriteLockChecks / 100 file', async (t) => {
+test('performFileAccessCheck / 100 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 100);
   } catch (error) {
@@ -751,7 +751,7 @@ test('performWriteLockChecks / 100 file', async (t) => {
   }
 });
 
-test('performWriteLockChecks / 1000 file', async (t) => {
+test('performFileAccessCheck / 1000 file', async (t) => {
   try {
     await performWriteLockCheckTest(t, 1000);
   } catch (error) {
@@ -760,7 +760,7 @@ test('performWriteLockChecks / 1000 file', async (t) => {
   }
 });
 
-test('performWriteLockChecks / no access', async (t) => {
+test('performFileAccessCheck / no access', async (t) => {
   try {
     const tmp = join(process.cwd(), 'tmp');
     fse.ensureDirSync(tmp);
@@ -774,16 +774,19 @@ test('performWriteLockChecks / no access', async (t) => {
     fse.chmodSync(tmpFile, fse.constants.O_RDONLY);
 
     const ioContext = new IoContext();
-    const error = await t.throwsAsync(() => ioContext.performWriteLockChecks(absDir, ['foo.txt']));
-    if (error) {
-      if (process.platform === 'win32' && error.message.startsWith('EPERM: operation not permitted, access')) {
+
+    await t.notThrowsAsync(() => ioContext.performFileAccessCheck(absDir, ['foo.txt'], TEST_IF.FILE_CAN_BE_READ_FROM));
+
+    const error2 = await t.throwsAsync(() => ioContext.performFileAccessCheck(absDir, ['foo.txt'], TEST_IF.FILE_CAN_BE_WRITTEN_TO));
+    if (error2) {
+      if (process.platform === 'win32' && error2.message.startsWith('EPERM: operation not permitted, access')) {
         t.log('succesfully detected foo.txt as not accessible');
         t.pass();
-      } else if (process.platform !== 'win32' && error.message.includes('permission denied')) {
+      } else if (process.platform !== 'win32' && error2.message.includes('permission denied')) {
         t.log('succesfully detected foo.txt as not accessible');
         t.pass();
       } else {
-        throw new Error(`expected function to detect foo.txt as not accessible but received: ${error.message}`);
+        throw new Error(`expected function to detect foo.txt as not accessible but received: ${error2.message}`);
       }
     } else {
       throw new Error('expected function to detect foo.txt as not accessible but function succeeded');

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -771,7 +771,7 @@ test('performFileAccessCheck / no access', async (t) => {
     t.log(`Create ${tmpFile}`);
     fse.ensureFileSync(tmpFile);
     t.log(`Set chmod(444) for ${tmpFile}`);
-    fse.chmodSync(tmpFile, fse.constants.O_RDONLY);
+    fse.chmodSync(tmpFile, fse.constants.S_IRUSR | fse.constants.S_IRGRP | fse.constants.S_IROTH);
 
     const ioContext = new IoContext();
 


### PR DESCRIPTION
The index class now performs a read-access check rather a write-access-check. Also fixed a race condition because the `mtime` was incorrectly set on Windows