### PR TITLE
:bug: speedup snowfs inside electron app

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { difference } from 'lodash';
 import {
   isAbsolute, join, relative, basename,
 } from './path';
+import * as io from './io';
 import * as fss from './fs-safe';
 import { IoContext, TEST_IF } from './io_context';
 import { Odb } from './odb';
@@ -75,7 +76,7 @@ export class Index {
    */
   invalidate(): Promise<void> {
     // check if index exists, this can be false if the commit has no files (--allowEmpty)
-    return fse.pathExists(this.getAbsPath()).then((exists: boolean) => {
+    return io.pathExists(this.getAbsPath()).then((exists: boolean) => {
       if (exists) { return fse.unlink(this.getAbsPath()); }
     }).then(() => {
       this.repo.removeIndex(this);

--- a/src/io.ts
+++ b/src/io.ts
@@ -66,98 +66,6 @@ export enum OSWALK {
   NO_RECURSIVE = 16
 }
 
-/**
- * Helper function to recursively request information of all files or directories of a given directory.
- * @param dirPath       The directory in question.
- * @param request       Specify which elements are of interest.
- * @param dirItemRef    Only for internal use, must be not set when called.
- */
-export function osWalk(dirPath: string, request: OSWALK): Promise<DirItem[]> {
-  const returnDirs = request & OSWALK.DIRS;
-  const returnFiles = request & OSWALK.FILES;
-  const returnHidden = request & OSWALK.HIDDEN;
-  const browseRepo = request & OSWALK.BROWSE_REPOS;
-
-  function internalOsWalk(dirPath: string, request: OSWALK, relPath: string, dirItemRef?: DirItem): Promise<DirItem[]> {
-    if (dirPath.endsWith('/')) {
-      // if directory ends with a seperator, we cut it off to ensure
-      // we don't return a path like /foo/directory//file.jpg
-      dirPath = dirPath.substr(0, dirPath.length - 1);
-    }
-
-    const dirItems = [];
-    const dirItemsTmp: DirItem[] = [];
-    return new Promise<string[]>((resolve, reject) => {
-      readdir(dirPath, (error, entries: string[]) => {
-        if (error) {
-          // While browsing through a sub-directory, readdir
-          // might fail if the directory e.g. gets deleted at the same
-          // time. Therefore sub-directories don't throw an error
-          if (dirItemRef) {
-            resolve([]);
-          } else {
-            reject(error);
-          }
-          return;
-        }
-
-        // normalize all dir items
-        resolve(entries.map(normalize));
-      });
-    })
-      .then((items: string[]) => {
-        const promises = [];
-
-        for (const item of items) {
-          if (item === '.DS_Store' || item === 'thumbs.db') {
-            continue;
-          } else if (!browseRepo && (item === '.snow' || item === '.git')) {
-            continue;
-          } else if (!returnHidden && item.startsWith('.')) {
-            continue;
-          }
-
-          const absPath = `${dirPath}/${item}`;
-
-          const stats = stat(absPath);
-          promises.push(stats);
-          dirItemsTmp.push({
-            absPath,
-            isempty: false,
-            relPath: relPath.length === 0 ? item : `${relPath}/${item}`,
-            stats: null, // not resolved yet.. (*)
-          });
-        }
-
-        return Promise.all(promises);
-      }).then((itemStatArray: Stats[]) => {
-        const promises = [];
-        let i = 0;
-        for (const itemStats of itemStatArray) {
-          const dirItem = dirItemsTmp[i++];
-          dirItem.stats = itemStats; // (*)...update stats which are now resolved
-
-          if ((itemStats.isDirectory() && returnDirs) || (!itemStats.isDirectory() && returnFiles)) {
-            dirItems.push(dirItem);
-          }
-
-          if (itemStats.isDirectory() && !(request & OSWALK.NO_RECURSIVE)) {
-            promises.push(internalOsWalk(dirItem.absPath, request, dirItem.relPath, dirItem));
-          }
-        }
-
-        if (dirItemRef) {
-          dirItemRef.isempty = itemStatArray.length === 0;
-        }
-
-        return Promise.all(promises);
-      })
-      .then((dirItemResults: DirItem[]) => dirItems.concat(...dirItemResults));
-  }
-
-  return internalOsWalk(dirPath, request, '');
-}
-
 function darwinZip(src: string, dst: string): Promise<void> {
   const p0 = cp.spawn('ditto', ['-c', '-k', '--sequesterRsrc', src, dst]);
   return new Promise((resolve, reject) => {
@@ -295,4 +203,96 @@ export function createReadStream(path: PathLike, options?: string | {
   highWaterMark?: number;
 }): fse.ReadStream {
   return fs.createReadStream(path, options);
+}
+
+/**
+ * Helper function to recursively request information of all files or directories of a given directory.
+ * @param dirPath       The directory in question.
+ * @param request       Specify which elements are of interest.
+ * @param dirItemRef    Only for internal use, must be not set when called.
+ */
+export function osWalk(dirPath: string, request: OSWALK): Promise<DirItem[]> {
+  const returnDirs = request & OSWALK.DIRS;
+  const returnFiles = request & OSWALK.FILES;
+  const returnHidden = request & OSWALK.HIDDEN;
+  const browseRepo = request & OSWALK.BROWSE_REPOS;
+
+  function internalOsWalk(dirPath: string, request: OSWALK, relPath: string, dirItemRef?: DirItem): Promise<DirItem[]> {
+    if (dirPath.endsWith('/')) {
+      // if directory ends with a seperator, we cut it off to ensure
+      // we don't return a path like /foo/directory//file.jpg
+      dirPath = dirPath.substr(0, dirPath.length - 1);
+    }
+
+    const dirItems = [];
+    const dirItemsTmp: DirItem[] = [];
+    return new Promise<string[]>((resolve, reject) => {
+      readdir(dirPath, (error, entries: string[]) => {
+        if (error) {
+          // While browsing through a sub-directory, readdir
+          // might fail if the directory e.g. gets deleted at the same
+          // time. Therefore sub-directories don't throw an error
+          if (dirItemRef) {
+            resolve([]);
+          } else {
+            reject(error);
+          }
+          return;
+        }
+
+        // normalize all dir items
+        resolve(entries.map(normalize));
+      });
+    })
+      .then((items: string[]) => {
+        const promises = [];
+
+        for (const item of items) {
+          if (item === '.DS_Store' || item === 'thumbs.db') {
+            continue;
+          } else if (!browseRepo && (item === '.snow' || item === '.git')) {
+            continue;
+          } else if (!returnHidden && item.startsWith('.')) {
+            continue;
+          }
+
+          const absPath = `${dirPath}/${item}`;
+
+          const stats = stat(absPath);
+          promises.push(stats);
+          dirItemsTmp.push({
+            absPath,
+            isempty: false,
+            relPath: relPath.length === 0 ? item : `${relPath}/${item}`,
+            stats: null, // not resolved yet.. (*)
+          });
+        }
+
+        return Promise.all(promises);
+      }).then((itemStatArray: Stats[]) => {
+        const promises = [];
+        let i = 0;
+        for (const itemStats of itemStatArray) {
+          const dirItem = dirItemsTmp[i++];
+          dirItem.stats = itemStats; // (*)...update stats which are now resolved
+
+          if ((itemStats.isDirectory() && returnDirs) || (!itemStats.isDirectory() && returnFiles)) {
+            dirItems.push(dirItem);
+          }
+
+          if (itemStats.isDirectory() && !(request & OSWALK.NO_RECURSIVE)) {
+            promises.push(internalOsWalk(dirItem.absPath, request, dirItem.relPath, dirItem));
+          }
+        }
+
+        if (dirItemRef) {
+          dirItemRef.isempty = itemStatArray.length === 0;
+        }
+
+        return Promise.all(promises);
+      })
+      .then((dirItemResults: DirItem[]) => dirItems.concat(...dirItemResults));
+  }
+
+  return internalOsWalk(dirPath, request, '');
 }

--- a/src/io.ts
+++ b/src/io.ts
@@ -12,8 +12,7 @@ export { PathLike, Stats } from 'fs-extra';
 // https://github.com/Snowtrack/SnowFS/issues/173
 let useOriginalFs = false;
 let fs;
-// eslint-disable-next-line no-prototype-builtins
-if (process.versions.hasOwnProperty('electron')) {
+if (Object.prototype.hasOwnProperty.call(process.versions, 'electron')) {
   // eslint-disable-next-line global-require, import/no-unresolved
   fs = require('original-fs');
   useOriginalFs = true;

--- a/src/io.ts
+++ b/src/io.ts
@@ -111,7 +111,7 @@ export function zipFile(src: string, dst: string, opts: {deleteSrc: boolean}): P
 export function hideItem(path: string): Promise<void> {
   if (winattr) {
     return new Promise<void>((resolve) => {
-      winattr.set(path, { hidden: true }, (_error) => {
+      winattr.set(path, { hidden: true }, () => {
         // not being able to hide the directory shouldn't stop us here
         // so we ignore the error
         resolve();

--- a/src/io.ts
+++ b/src/io.ts
@@ -178,7 +178,7 @@ export function copyFile(src: PathLike, dest: PathLike, flags: number): Promise<
  * For more information check the module import ocmments above.
  * For more information about the API of [readdir] visit https://nodejs.org/api/fs.html#fs_fs_readdir_path_options_callback
  */
-export function readdir(path: PathLike, callback: (err: Error | null, files: string[]) => void) {
+export function readdir(path: PathLike, callback: (err: Error | null, files: string[]) => void): void {
   return fs.readdir(path, callback);
 }
 

--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -1,6 +1,5 @@
 import * as cp from 'child_process';
 import * as fse from 'fs-extra';
-import * as fss from './fs-safe';
 import * as os from 'os';
 
 import { exec, spawn } from 'child_process';

--- a/src/odb.ts
+++ b/src/odb.ts
@@ -7,6 +7,7 @@ import {
 import {
   DirItem, OSWALK, osWalk, zipFile,
 } from './io';
+import * as io from './io';
 import * as fss from './fs-safe';
 
 import { Repository, RepositoryInitOptions } from './repository';
@@ -52,7 +53,7 @@ export class Odb {
 
   static create(repo: Repository, options: RepositoryInitOptions): Promise<Odb> {
     const odb: Odb = new Odb(repo);
-    return fse.pathExists(options.commondir)
+    return io.pathExists(options.commondir)
       .then((exists: boolean) => {
         if (exists) {
           throw new Error('directory already exists');
@@ -259,7 +260,7 @@ export class Odb {
         filehash = res.filehash;
         hashBlocks = res.hashBlocks;
         dstFile = join(objects, filehash.substr(0, 2), filehash.substr(2, 2), filehash.toString() + extname(filepath));
-        return fse.pathExists(dstFile);
+        return io.pathExists(dstFile);
       })
       .then((exists: boolean) => {
         if (exists) {
@@ -291,7 +292,7 @@ export class Odb {
         }
         return Promise.resolve();
       })
-      .then(() => fse.stat(filepath)
+      .then(() => io.stat(filepath)
         .then((stat: fse.Stats) => ({
           file: relative(this.repo.repoWorkDir, filepath),
           fileinfo: {
@@ -311,7 +312,7 @@ export class Odb {
     const hash: string = file.hash;
     const objectFile: string = this.getAbsObjectPath(file);
 
-    return fse.pathExists(objectFile)
+    return io.pathExists(objectFile)
       .then((exists: boolean) => {
         if (!exists) {
           throw new Error(`object ${hash} not found`);

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -2,6 +2,7 @@
 
 import * as fse from 'fs-extra';
 import * as crypto from 'crypto';
+import * as io from './io';
 import {
   resolve, join, dirname, extname,
 } from './path';
@@ -36,6 +37,10 @@ export enum COMMIT_ORDER {
 export enum REFERENCE_TYPE {
   BRANCH = 0
 }
+
+const warningMessage = `Attention: Modifications to the content of this directory without the proper knowledge might result in data loss.
+
+Only proceed if you know exactly what you are doing!`;
 
 /**
  * Initialize a new [[Repository]].
@@ -254,7 +259,7 @@ export class StatusEntry {
 
 function getSnowFSRepo(path: string): Promise<string | null> {
   const snowInit: string = join(path, '.snow');
-  return fse.pathExists(snowInit).then((exists: boolean) => {
+  return io.pathExists(snowInit).then((exists: boolean) => {
     if (exists) {
       return path;
     }
@@ -868,7 +873,7 @@ export class Repository {
 
     // First iterate over all files and get their file stats
     const snowtrackIgnoreDefault: string = join(this.repoWorkDir, '.snowignore');
-    return fse.pathExists(snowtrackIgnoreDefault)
+    return io.pathExists(snowtrackIgnoreDefault)
       .then((exists: boolean) => {
         if (exists) {
           return ignore.loadFile(snowtrackIgnoreDefault);
@@ -1148,14 +1153,21 @@ export class Repository {
     let odb: Odb = null;
     let commondirInside: string = null;
     let commondir: string = null;
-    return getSnowFSRepo(workdir).then((snowFSRepoPath: string | null) => {
-      if (!snowFSRepoPath) {
-        throw new Error('not a SnowFS repository (or any of the parent directories): .snow');
-      }
-      workdir = snowFSRepoPath;
-      commondirInside = join(workdir, '.snow');
-      return fse.stat(commondirInside);
-    })
+    return io.pathExists(workdir)
+      .then((exists: boolean) => {
+        if (!exists) {
+          throw new Error('workdir doesn\'t exist');
+        }
+        return getSnowFSRepo(workdir);
+      })
+      .then((snowFSRepoPath: string | null) => {
+        if (!snowFSRepoPath) {
+          throw new Error('directory contains no .snow');
+        }
+        workdir = snowFSRepoPath;
+        commondirInside = join(workdir, '.snow');
+        return io.stat(commondirInside);
+      })
       .then((stat: fse.Stats) => {
         if (stat.isFile()) {
           return fse.readFile(commondirInside).then((buf: Buffer) => buf.toString());
@@ -1165,11 +1177,11 @@ export class Repository {
       })
       .then((commondirResult: string) => {
         commondir = commondirResult;
-        return fse.pathExists(commondir);
+        return io.pathExists(commondir);
       })
       .then((exists: boolean) => {
         if (!exists) throw new Error('commondir not found');
-        return fse.stat(commondir);
+        return io.stat(commondir);
       })
       .then((stat: fse.Stats) => {
         if (!stat.isDirectory()) throw new Error('commondir must be a directory');

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -38,10 +38,6 @@ export enum REFERENCE_TYPE {
   BRANCH = 0
 }
 
-const warningMessage = `Attention: Modifications to the content of this directory without the proper knowledge might result in data loss.
-
-Only proceed if you know exactly what you are doing!`;
-
 /**
  * Initialize a new [[Repository]].
  */

--- a/src/treedir.ts
+++ b/src/treedir.ts
@@ -2,7 +2,6 @@
 /* eslint-disable no-useless-constructor */
 import * as fse from 'fs-extra';
 import * as crypto from 'crypto';
-import * as fss from './fs-safe';
 import * as io from './io';
 
 import {

--- a/src/treedir.ts
+++ b/src/treedir.ts
@@ -2,6 +2,8 @@
 /* eslint-disable no-useless-constructor */
 import * as fse from 'fs-extra';
 import * as crypto from 'crypto';
+import * as fss from './fs-safe';
+import * as io from './io';
 
 import {
   join, relative, normalize, extname,
@@ -91,7 +93,7 @@ export class TreeFile extends TreeEntry {
 
   isFileModified(repo: Repository, detectionMode: DETECTIONMODE): Promise<{file : TreeFile; modified : boolean, newStats: fse.Stats}> {
     const filepath = join(repo.workdir(), this.path);
-    return fse.stat(filepath).then((newStats: fse.Stats) => {
+    return io.stat(filepath).then((newStats: fse.Stats) => {
       // first we check for for modification time and file size
       if (this.stats.size !== newStats.size) {
         return { file: this, modified: true, newStats };
@@ -266,7 +268,7 @@ export function constructTree(
   }
 
   return new Promise<string[]>((resolve, reject) => {
-    fse.readdir(dirPath, (error, entries: string[]) => {
+    io.readdir(dirPath, (error, entries: string[]) => {
       if (error) {
         reject(error);
         return;
@@ -284,7 +286,7 @@ export function constructTree(
 
         const absPath = `${dirPath}/${entry}`;
         promises.push(
-          fse.stat(absPath).then((stat: fse.Stats) => {
+          io.stat(absPath).then((stat: fse.Stats) => {
             if (stat.isDirectory()) {
               const subtree: TreeDir = new TreeDir(
                 relative(root, absPath),


### PR DESCRIPTION
This bugfix uses the original `fs` module inside an Electron app. it is recommended, to use the `./io` module from now on whenever possible to ensure that either `fs` or `original-fs` is used.