### PR TITLE
Prevent osWalk from failing (Closes: #192)

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -331,7 +331,6 @@ export function osWalk(dirPath: string, request: OSWALK): Promise<DirItem[]> {
     }
 
     const dirItems = [];
-    const dirItemsTmp: DirItem[] = [];
     return new Promise<string[]>((resolve, reject) => {
       readdir(dirPath, (error, entries: string[]) => {
         if (error) {
@@ -378,7 +377,7 @@ export function osWalk(dirPath: string, request: OSWALK): Promise<DirItem[]> {
         return Promise.all(promises);
       }).then((itemStatArray: DirItem[]) => {
         const promises = [];
-        const i = 0;
+
         for (const dirItem of itemStatArray.filter((x) => x)) {
           if ((dirItem.stats.isDirectory() && returnDirs) || (!dirItem.stats.isDirectory() && returnFiles)) {
             dirItems.push(dirItem);

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -49,6 +49,14 @@ const exampleFiles = [
 const LOG_DIRECTORY = 'Check getRepoDetails(..) with directory path';
 const LOG_FILE = 'Check getRepoDetails(..) with  filepath:';
 
+async function sleep(delay) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, delay);
+  });
+}
+
 async function createDirs(t, tmpDir: string, dirs: string[]) {
   if (dirs.length === 0) {
     return Promise.resolve();
@@ -780,14 +788,6 @@ test('fss.writeSafeFile test', async (t) => {
     t.fail(error.message);
   }
 });
-
-async function sleep(delay) {
-  return new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, delay);
-  });
-}
 
 async function performWriteLockCheckTest(t, fileCount: number) {
   if (fileCount === 0) {


### PR DESCRIPTION
This PR prevents `osWalk` from failing if an item in the directory fails on `stat` which might be the case for a deleted item while iterating.

This PR also introduces two intensive unit-tests that test...

1. ... deleting while iterating.
2. ... moving an entire directory out and back the directory while osWalk is running