### PR TITLE
Bugfix/issue 195

### DIFF
--- a/resources/win-access.exe
+++ b/resources/win-access.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d56a427cff0376f586bee25ce7da0d84ea3682823f67cdf28f8f49e5b486d439
-size 50688
+oid sha256:b2112915b66a681d09a351e8c0dbc23e466da8df68f53b4d83b4f51a3a499aa0
+size 580608

--- a/src/io.ts
+++ b/src/io.ts
@@ -331,7 +331,6 @@ export function osWalk(dirPath: string, request: OSWALK): Promise<DirItem[]> {
     }
 
     const dirItems = [];
-    const dirItemsTmp: DirItem[] = [];
     return new Promise<string[]>((resolve, reject) => {
       readdir(dirPath, (error, entries: string[]) => {
         if (error) {
@@ -378,7 +377,7 @@ export function osWalk(dirPath: string, request: OSWALK): Promise<DirItem[]> {
         return Promise.all(promises);
       }).then((itemStatArray: DirItem[]) => {
         const promises = [];
-        const i = 0;
+
         for (const dirItem of itemStatArray.filter((x) => x)) {
           if ((dirItem.stats.isDirectory() && returnDirs) || (!dirItem.stats.isDirectory() && returnFiles)) {
             dirItems.push(dirItem);

--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -169,7 +169,7 @@ export namespace win32 {
             }
           } catch (error) {
             // throw an error if something happened during JSON.parse
-            throw new Error(error);
+            reject(new Error(error));
           }
         }
       });

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -49,6 +49,14 @@ const exampleFiles = [
 const LOG_DIRECTORY = 'Check getRepoDetails(..) with directory path';
 const LOG_FILE = 'Check getRepoDetails(..) with  filepath:';
 
+async function sleep(delay) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, delay);
+  });
+}
+
 async function createDirs(t, tmpDir: string, dirs: string[]) {
   if (dirs.length === 0) {
     return Promise.resolve();
@@ -780,14 +788,6 @@ test('fss.writeSafeFile test', async (t) => {
     t.fail(error.message);
   }
 });
-
-async function sleep(delay) {
-  return new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, delay);
-  });
-}
 
 async function performWriteLockCheckTest(t, fileCount: number) {
   if (fileCount === 0) {


### PR DESCRIPTION
Recompiled `win-access.exe` with clang to remove the VC dependency. Also fixed an issue where `throw` was used instead of `reject`.