### PR TITLE
Speeding up moving files to the recycle bin

### DIFF
--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -12,6 +12,9 @@ import * as io from './io';
 const AggregateError = require('es-aggregate-error');
 const drivelist = require('drivelist');
 
+// eslint-disable-next-line import/order
+const PromisePool = require('@supercharge/promise-pool');
+
 class StacklessError extends Error {
   constructor(...args) {
     super(...args);
@@ -333,7 +336,7 @@ function getFilesystem(drive: any, mountpoint: string) {
   return FILESYSTEM.OTHER;
 }
 
-type TrashExecutor = string | ((item: string) => void);
+type TrashExecutor = string | ((item: string[] | string) => void);
 
 /**
  * Class to be instantiated to speedup certain I/O operations by acquiring information
@@ -637,9 +640,15 @@ export class IoContext {
               return win32.checkReadAccess(absPaths, relPaths);
             case TEST_IF.FILE_CAN_BE_WRITTEN_TO:
             default:
-              // check if files are touched by any other process.
+              // Check if files are touched by any other process.
               // Files that are opened by another process cannot be replaced, moved or deleted.
-              return win32.checkWriteAccess(IoContext, absPaths);
+              // The current limit to check for write access on Windows is 5000 which takes around
+              // 10 seconds on my machine. Everything below simply takes too long. In that case
+              // we let the proceeding function fail
+              if (absPaths.length <= 5000) {
+                return win32.checkWriteAccess(IoContext, absPaths);
+              }
+              return Promise.resolve();
           }
         });
     }
@@ -694,20 +703,32 @@ export class IoContext {
   }
 
   /**
-   * Move a file into the trash of the operating system. `SnowFS` tends to avoid
-   * destructive delete operations at all costs, and rather moves files into the trash.
+   * Move files into the trash of the operating system. `SnowFS` avoids
+   * destructive delete operations at all costs, and rather moves files to trash.
    *
-   * @param absPath     The file or directory to move to the trash.
-   * @param relPath     Optional path used in an error message in case the operation fails.
-   *                    Used to make error messages shorter.
-   * @param execPath    If `SnowFS` is embedded in another application, the resource path
-   *                    might be located somewhere else. Can be set so `SnowFS` can find
-   *                    the executables.
+   * @param absPaths    The file(s) or directory to move to the trash.
   */
-  static putToTrash(absPath: string, relPath?: string): Promise<void> {
+  static putToTrash(absPaths: string[] | string): Promise<void[]> {
+    if (typeof absPaths === 'string') {
+      absPaths = [absPaths];
+    }
+
+    if (!Array.isArray(absPaths)) { // assertion absPath is an array
+      return Promise.all([]);
+    }
+
+    // just to be on the safe side
+    absPaths.forEach((absPath: string) => {
+      if ((process.platform === 'win32' && absPath.length <= 3) // X:\
+          || (process.platform === 'darwin' && absPath.length <= 1) // '/'
+      ) {
+        throw new Error(`cannot move '${absPath}' to trash`);
+      }
+    });
+
     if (IoContext.trashExecutor && typeof IoContext.trashExecutor !== 'string') {
-      IoContext.trashExecutor(absPath);
-      return Promise.resolve();
+      IoContext.trashExecutor(absPaths);
+      return Promise.all([]);
     }
 
     let trashPath: string;
@@ -760,14 +781,34 @@ export class IoContext {
       }
     }
 
-    return io.pathExists(absPath)
-      .then((exists: boolean) => {
-        if (!exists) {
-          throw new Error(`${absPath} no such file or directory`);
-        }
+    // Slice the array into multiple arrays because
+    // the trash executables allow multiple arguments.
+    //  $ trash path [...]
+    //  $ recycle-bin.exe path [...]
+    // The amount of arguments is limited and
+    // 4096 is a good compromise for macOS and Windows
+    const chunks: string[][] = [];
+    let currentSize = 0;
+    let currentChunk = [];
+    chunks.push(currentChunk);
+    for (const absPath of absPaths) {
+      if (currentSize + absPath.length + 1 > 4096) {
+        currentSize = 0;
+        currentChunk = [];
+        chunks.push(currentChunk);
+      }
 
-        return new Promise((resolve, reject) => {
-          const proc = spawn(trashPath, [absPath]);
+      currentSize += absPath.length + 1;
+      currentChunk.push(absPath);
+    }
+
+    return PromisePool
+      .withConcurrency(8)
+      .for(chunks)
+      .handleError((error) => { throw error; }) // Uncaught errors will immediately stop PromisePool
+      .process((path: string[]) => {
+        return new Promise<void>((resolve, reject) => {
+          const proc = spawn(trashPath, path);
 
           proc.on('exit', (code: number) => {
             if (code === 0) {
@@ -775,9 +816,9 @@ export class IoContext {
             } else {
               const stderr = proc.stderr.read();
               if (stderr) {
-                reject(stderr.toString());
+                reject(new Error(stderr.toString()));
               } else {
-                reject(new Error(`cannot move '${relPath ?? absPath}' to trash`));
+                reject(new Error('deleting files failed'));
               }
             }
           });

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -267,60 +267,86 @@ export class StatusEntry {
   }
 }
 
-function getSnowFSRepo(path: string): Promise<string | null> {
-  const snowInit: string = join(path, '.snow');
-  return io.pathExists(snowInit).then((exists: boolean) => {
-    if (exists) {
-      return path;
-    }
+export function getSnowFSRepo(dirpath: string): Promise<string | null> {
+  const snowInit: string = join(dirpath, '.snow');
+  return io.pathExists(snowInit)
+    .then((exists: boolean) => {
+      if (exists) {
+        return dirpath;
+      }
 
-    if (dirname(path) === path) { // if arrived at root
-      throw new Error('commondir not found');
-    }
+      if (dirname(dirpath) === dirpath) { // if arrived at root
+        throw new Error('commondir not found');
+      }
 
-    return getSnowFSRepo(dirname(path));
-  });
+      return getSnowFSRepo(dirname(dirpath));
+    });
+}
+
+/**
+ * Retrieve the common dir of a workdir path.
+ * If the path could not be retrieved the function returns null.
+ * @param workdir     The absolute path to the root of the workdir.
+ * @returns           The absolute path to the commondir or null.
+ */
+export function getCommondir(workdir: string): Promise<string | null> {
+  const commondir = join(workdir, '.snow');
+  return io.stat(commondir)
+    .then((stat: fse.Stats) => {
+      if (stat.isFile()) {
+        return fse.readFile(commondir)
+          .then((buf: Buffer) => buf.toString());
+      }
+
+      return commondir;
+    })
+    .catch(() => null);
 }
 
 /**
  * Delete an item or move it to the trash/recycle-bin if the file has a shadow copy in the object database.
  */
-function deleteOrTrash(repo: Repository, absPath: string, relPath: string): Promise<void> {
+function deleteOrTrash(repo: Repository, absPath: string, putToTrash: string[]): Promise<void> {
   let isDirectory: boolean;
   return io.stat(absPath)
     .then((stat: fse.Stats) => {
       isDirectory = stat.isDirectory();
 
-      const promises = [];
+      const calculateHash: string[] = [];
       if (stat.isDirectory()) {
         return io.osWalk(absPath, io.OSWALK.FILES)
           .then((items: io.DirItem[]) => {
             for (const item of items) {
-              promises.push(calculateFileHash(item.absPath)
-                .then((res: {filehash: string, hashBlocks?: HashBlock[]}) => {
-                  return { absPath: item.absPath, filehash: res.filehash };
-                }));
+              calculateHash.push(item.absPath);
             }
-            return Promise.all(promises);
+            return Promise.resolve(calculateHash);
           });
       }
-      promises.push(calculateFileHash(absPath)
-        .then((res: {filehash: string, hashBlocks?: HashBlock[]}) => {
-          return { absPath, filehash: res.filehash };
-        }));
-
-      return Promise.all(promises);
-    }).then((res: {absPath: string, filehash: string}[]) => {
+      return Promise.resolve([absPath]);
+    }).then((calculateHashFrom: string[]) => {
+      return PromisePool
+        .withConcurrency(8)
+        .for(calculateHashFrom)
+        .handleError((error) => { throw error; }) // Uncaught errors will immediately stop PromisePool
+        .process((path: string) => {
+          return calculateFileHash(path)
+            .then((res: {filehash: string, hashBlocks?: HashBlock[]}) => {
+              return { absPath: path, filehash: res.filehash };
+            });
+        });
+    }).then((res: {results: {absPath: string, filehash: string}[]}) => {
       const promises = [];
-      for (const r of res) {
+      for (const r of res.results) {
         promises.push(repo.repoOdb.getObjectByHash(r.filehash, extname(r.absPath)));
       }
       return Promise.all(promises);
-    }).then((stats: (fse.Stats | null)[]) => {
+    })
+    .then((stats: (fse.Stats | null)[]) => {
       if (stats.includes(null)) {
         // if there is one null stats object, it means that file isn't stored
         // in the object database, and therefore needs to go to the trash
-        return IoContext.putToTrash(absPath, relPath);
+        putToTrash.push(absPath);
+        return Promise.resolve();
       }
       if (isDirectory) {
         return io.rmdir(absPath);
@@ -782,8 +808,12 @@ export class Repository {
     // Array of async functions that are executed by the promise pool
     const tasks: IoTask[] = [];
 
-    // Array of relative paths to files that will undergo the write-lock check
-    const relPathChecks: string[] = [];
+    // Array of relative paths to files that will undergo the write access check
+    const performAccessCheck: string[] = [];
+
+    const putToTrash: string[] = [];
+
+    const oldHeadHash = this.head.hash;
 
     const ioContext = new IoContext();
     return ioContext.init()
@@ -834,19 +864,23 @@ export class Repository {
             const tfile = oldFilesMap.get(status.path);
             if (tfile) {
               if (tfile instanceof TreeFile) {
-                relPathChecks.push(tfile.path);
-                tasks.push(() => tfile.isFileModified(this, detectionMode).then((res: {file: TreeFile, modified : boolean}) => {
-                  if (res.modified) {
-                    const dst: string = join(this.repoWorkDir, res.file.path);
+                performAccessCheck.push(tfile.path);
 
-                    // We first delete or trash the file before writing to ensure an item that has never been saved
-                    // to the object database will end in the trash and will not be simply overwritten by [Odb.readObject].
-                    return deleteOrTrash(this, dst, res.file.path)
-                      .then(() => {
-                        return this.repoOdb.readObject(res.file, dst, ioContext);
-                      });
-                  }
-                }));
+                const dst: string = join(this.repoWorkDir, tfile.path);
+
+                // We first use deleteOrTrash to delete/trash the item because it checks if the item is backed up
+                // in the version database and rather sends it to trash than destroying the data
+                const putToTrashImmediately = [];
+                tasks.push(() => deleteOrTrash(this, dst, putToTrashImmediately)
+                  .then(() => {
+                    // Since we replace the object, we can delete the object immediately and we don't
+                    // need to treat it as a delete candidate
+                    if (putToTrashImmediately.length > 0) {
+                      return IoContext.putToTrash(putToTrashImmediately);
+                    }
+                  }).then(() => {
+                    return this.repoOdb.readObject(tfile, dst, ioContext);
+                  }));
               }
             } else {
               throw new Error(`File '${tfile.path}' not found during last-modified-check`);
@@ -879,15 +913,15 @@ export class Repository {
                 }
               });
               /// ... the delete operation below.
-              tasks.push(() => deleteOrTrash(this, join(this.workdir(), candidate.path), candidate.path));
+              tasks.push(() => deleteOrTrash(this, join(this.workdir(), candidate.path), putToTrash));
             }
           } else {
-            relPathChecks.push(candidate.path);
-            tasks.push(() => deleteOrTrash(this, join(this.workdir(), candidate.path), candidate.path));
+            performAccessCheck.push(candidate.path);
+            tasks.push(() => deleteOrTrash(this, join(this.workdir(), candidate.path), putToTrash));
           }
         });
 
-        return ioContext.performFileAccessCheck(this.workdir(), relPathChecks, TEST_IF.FILE_CAN_BE_WRITTEN_TO);
+        return ioContext.performFileAccessCheck(this.workdir(), performAccessCheck, TEST_IF.FILE_CAN_BE_WRITTEN_TO);
       })
       .then(() => {
         // After we received the target commit, we update the commit and reference
@@ -908,6 +942,11 @@ export class Repository {
           .process((task: IoTask) => task());
       })
       .then(() => {
+        if (putToTrash.length > 0) {
+          return IoContext.putToTrash(putToTrash);
+        }
+      })
+      .then(() => {
         let moveTo = '';
         if (target instanceof Reference) {
           moveTo = target.getName();
@@ -916,7 +955,7 @@ export class Repository {
         } else {
           moveTo = target;
         }
-        return this.repoLog.writeLog(`checkout: move to '${moveTo}' at ${targetCommit.hash} with ${reset}`);
+        return this.repoLog.writeLog(`checkout: move from '${oldHeadHash}' to ${targetCommit.hash} with ${reset}`);
       });
   }
 


### PR DESCRIPTION
This PR speeds up the moving files to the recycle-bin/trash. The corresponding executables (recycle-bin.exe/trash) accept multiple files as input. Instead of calling the process for each file manually, they are now bundled into chunks.

Additionally, a PromisePool is used to prevent a process flood.