### PR TITLE
set typescript version to 4.3.4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "version" : "4.3.4",
   "compileOnSave": false,
   "compilerOptions": {
     "module": "commonjs",


### PR DESCRIPTION
VScode might accidentally use a wrong TypeScript version.
Adding a `settings.json` file and setting the version in `tsconfig.json`.