### PR TITLE
:bug: Bugfix/issue 232

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1507,7 +1507,19 @@ export class Repository {
       opts.commondir = join(workdir, '.snow');
     }
 
-    return io.ensureDir(workdir)
+    return fse.pathExists(workdir)
+      .then((workdirExists: boolean) => {
+        if (workdirExists) {
+          throw new Error('workdir already exists');
+        }
+        return fse.pathExists(opts.commondir)
+          .then((commondirExists: boolean) => {
+            if (commondirExists) {
+              throw new Error('commondir already exists');
+            }
+            return io.ensureDir(workdir);
+          });
+      })
       .then(() => Odb.create(repo, opts))
       .then((odb: Odb) => {
         repo.repoOdb = odb;

--- a/test/2.repo.init.ts
+++ b/test/2.repo.init.ts
@@ -11,19 +11,10 @@ import { Commit } from '../src/commit';
 
 import { Reference } from '../src/reference';
 import { COMMIT_ORDER, Repository } from '../src/repository';
-
-function createRepoPath(): string {
-  while (true) {
-    const name = crypto.createHash('sha256').update(process.hrtime().toString()).digest('hex').substring(0, 6);
-    const repoPath = join(tmpdir(), 'snowtrack-repo', name);
-    if (!fse.pathExistsSync(repoPath)) {
-      return repoPath;
-    }
-  }
-}
+import { getRandomPath } from './helper';
 
 test('repo commondir', async (t) => {
-  const repoPath = createRepoPath();
+  const repoPath = getRandomPath();
   const commondirInside = repoPath;
 
   const error1 = t.throws(() => Repository.initExt(repoPath, { commondir: commondirInside }));
@@ -34,7 +25,7 @@ test('repo commondir', async (t) => {
   t.is(error2.message, 'commondir must be outside repository');
   t.false(fse.pathExistsSync(repoPath), 'repo must not exist yet');
 
-  const commondirOutside = createRepoPath();
+  const commondirOutside = getRandomPath();
   await t.notThrowsAsync(() => Repository.initExt(repoPath, { commondir: commondirOutside }));
   t.true(fse.pathExistsSync(repoPath), 'repo must have been created');
 });
@@ -102,8 +93,8 @@ export function testRepoCommondirInside(t, repo: Repository): Promise<void> {
 }
 
 test('repo init-commondir-outside', async (t) => {
-  const repoPath = createRepoPath();
-  const commondir = createRepoPath();
+  const repoPath = getRandomPath();
+  const commondir = getRandomPath();
 
   let repo: Repository;
   await Repository.initExt(repoPath, { commondir })
@@ -116,7 +107,7 @@ test('repo init-commondir-outside', async (t) => {
 });
 
 test('repo init-commondir-inside', async (t) => {
-  const repoPath = createRepoPath();
+  const repoPath = getRandomPath();
 
   let repo: Repository;
   await Repository.initExt(repoPath)

--- a/test/3.repo.open.ts
+++ b/test/3.repo.open.ts
@@ -88,3 +88,34 @@ test('repo open-commondir-inside-subdirectory', async (t) => {
     })
     .then(() => rmdir(repo.workdir()));
 });
+
+test('repo open-repo-workdir-commondir-collision-test', async (t) => {
+  /** This test ensures that Repository.initExt never overwrites another repo if executed on the same directory */
+  let workdir: string;
+  let commondir: string;
+
+  // create repo
+  workdir = getRandomPath();
+  await Repository.initExt(workdir);
+  // attempt to create repo at same location
+  const error1 = await t.throwsAsync(async () => Repository.initExt(workdir));
+  t.is(error1.message, 'workdir already exists');
+
+  // create repo
+  workdir = getRandomPath();
+  commondir = getRandomPath();
+  await Repository.initExt(workdir, { commondir });
+  // create repo at another location but with same commondir
+  workdir = getRandomPath();
+  const error2 = await t.throwsAsync(async () => Repository.initExt(workdir, { commondir }));
+  t.is(error2.message, 'commondir already exists');
+
+  // create repo
+  workdir = getRandomPath();
+  commondir = getRandomPath();
+  await Repository.initExt(workdir, { commondir });
+  // attempt to use different commondirs but same workdir
+  commondir = getRandomPath();
+  const error3 = await t.throwsAsync(async () => Repository.initExt(workdir, { commondir }));
+  t.is(error3.message, 'workdir already exists');
+});

--- a/test/3.repo.open.ts
+++ b/test/3.repo.open.ts
@@ -1,15 +1,15 @@
 import test from 'ava';
 import * as fse from 'fs-extra';
 import { join } from '../src/path';
-import { createRepoPath } from './helper';
+import { getRandomPath } from './helper';
 
 import { rmdir } from '../src/io';
 import { Repository } from '../src/repository';
 import { testRepoCommondirInside, testRepoCommondirOutside } from './2.repo.init';
 
 test('repo open-commondir-outside', async (t) => {
-  const repoPath = createRepoPath();
-  const commondir = createRepoPath();
+  const repoPath = getRandomPath();
+  const commondir = getRandomPath();
 
   let repo: Repository;
   t.log(`Initialize repo at ${repoPath}`);
@@ -29,8 +29,8 @@ test('repo open-commondir-outside', async (t) => {
 test('repo open-commondir-outside-subdirectory', async (t) => {
   /* Create a repository with a subdirectory and open the repo from the subdirectory.
   The test ensures that Repository.open travels up the hierarchy to find the next .snow repo */
-  const repoPath = createRepoPath();
-  const commondir = createRepoPath();
+  const repoPath = getRandomPath();
+  const commondir = getRandomPath();
 
   let repo: Repository;
   t.log(`Initialize repo at ${repoPath}`);
@@ -51,7 +51,7 @@ test('repo open-commondir-outside-subdirectory', async (t) => {
 });
 
 test('repo open-commondir-inside', async (t) => {
-  const repoPath = createRepoPath();
+  const repoPath = getRandomPath();
 
   let repo: Repository;
   t.log(`Initialize repo at ${repoPath}`);
@@ -70,7 +70,7 @@ test('repo open-commondir-inside', async (t) => {
 test('repo open-commondir-inside-subdirectory', async (t) => {
   /* Create a repository with a subdirectory and open the repo from the subdirectory.
   The test ensures that Repository.open travels up the hierarchy to find the next .snow repo */
-  const repoPath = createRepoPath();
+  const repoPath = getRandomPath();
 
   let repo: Repository;
   t.log(`Initialize repo at ${repoPath}`);

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -28,16 +28,6 @@ export function getRandomPath(): string {
   }
 }
 
-export function createRepoPath(): string {
-  while (true) {
-    const name = crypto.createHash('sha256').update(process.hrtime().toString()).digest('hex').substring(0, 6);
-    const repoPath = join(os.tmpdir(), 'snowtrack-repo', name);
-    if (!fse.pathExistsSync(repoPath)) {
-      return repoPath;
-    }
-  }
-}
-
 export function createRandomString(length: number): string {
   let result = '';
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';


### PR DESCRIPTION
Fixes and closes #232 by adding a check to ensure `Repository.init` never replaces a workdir or commondir