### PR TITLE
only complain if .snow exists

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1507,18 +1507,17 @@ export class Repository {
       opts.commondir = join(workdir, '.snow');
     }
 
-    return fse.pathExists(workdir)
+    return fse.pathExists(join(workdir, '.snow'))
       .then((workdirExists: boolean) => {
         if (workdirExists) {
           throw new Error('workdir already exists');
         }
-        return fse.pathExists(opts.commondir)
-          .then((commondirExists: boolean) => {
-            if (commondirExists) {
-              throw new Error('commondir already exists');
-            }
-            return io.ensureDir(workdir);
-          });
+        return fse.pathExists(opts.commondir);
+      }).then((commondirExists: boolean) => {
+        if (commondirExists) {
+          throw new Error('commondir already exists');
+        }
+        return io.ensureDir(workdir);
       })
       .then(() => Odb.create(repo, opts))
       .then((odb: Odb) => {


### PR DESCRIPTION
`Repository.init` checked for the existence of workdir, instead it must check for `workdir/.snow` to complain about the existence.