### PR TITLE
ignore temp files in refs and versions (Closes: #293)

### DIFF
--- a/src/odb.ts
+++ b/src/odb.ts
@@ -83,6 +83,9 @@ export class Odb {
       .then((value: DirItem[]) => {
         const promises = [];
         for (const ref of value) {
+          if (ref.relPath.endsWith('.tmp')) {
+            continue;
+          }
           promises.push(fse.readFile(ref.absPath).then((buf: Buffer) => JSON.parse(buf.toString())));
         }
         return Promise.all(promises);
@@ -157,6 +160,9 @@ export class Odb {
       .then((value: DirItem[]) => {
         const promises = [];
         for (const ref of value) {
+          if (ref.relPath.endsWith('.tmp')) {
+            continue;
+          }
           promises.push(this.readReference(ref));
         }
         return Promise.all(promises);


### PR DESCRIPTION
This PR ignores all `*.tmp` files in `refs` and `versions` and comes with a unit-test