### PR TITLE
use alternative read check if file is opened in read+write mode

### DIFF
--- a/src/io_context.ts
+++ b/src/io_context.ts
@@ -62,74 +62,68 @@ function strEncodeUTF16(str: string) {
   return new Uint8Array(buf);
 }
 
-export namespace win32 {
+/**
+ * Generic (OS-independent) implementation to check if the passed files are written to by another process.
+ * The paths of `absPaths` must be derived from `relPaths`. The order and length of both arrays must be equal.
+ *
+ * @param absPaths  Absolute paths of files to check.
+ * @param relPaths  Relative paths of files to check.
+ * @throws          Throws an AggregateError with a description of the effected files.
+ */
+export function checkReadAccess(absPaths: string[], relPaths: string[]): Promise<void> {
+  const promises: Promise<fse.Stats>[] = [];
 
-  /**
-   * Check if the passed files are written to by another process. The paths of `absPaths`
-   * must be derived from `relPaths`. The order and length of both arrays must be equal.
-   *
-   * @param absPaths  Absolute paths of files to check.
-   * @param relPaths  Relative paths of files to check.
-   * @throws          Throws an AggregateError with a description of the effected files.
-   */
-  export function checkReadAccess(absPaths: string[], relPaths: string[]): Promise<void> {
-    const promises = [];
-
-    for (const absPath of absPaths) {
-      promises.push(io.stat(absPath));
-    }
-
-    const stats1 = new Map<string, fse.Stats>();
-
-    return Promise.all(promises)
-      .then((stats: fse.Stats[]) => {
-        if (stats.length !== relPaths.length) {
-          throw new Error('Internal error: stats != paths');
-        }
-
-        for (let i = 0; i < relPaths.length; ++i) {
-          stats1.set(relPaths[i], stats[i]);
-        }
-
-        return new Promise<void>((resolve) => {
-          setTimeout(() => {
-            resolve();
-          }, 500);
-        });
-      }).then(() => {
-        const promises = [];
-
-        for (const absPath of absPaths) {
-          promises.push(io.stat(absPath));
-        }
-
-        return Promise.all(promises);
-      })
-      .then((stats: fse.Stats[]) => {
-        if (stats.length !== relPaths.length) {
-          throw new Error('Internal error: stats != paths');
-        }
-
-        const errors: Error[] = [];
-
-        for (let i = 0; i < relPaths.length; ++i) {
-          const prevStats = stats1.get(relPaths[i]);
-          // When a file is being written by another process, either...
-          // ... the size changes through time (e.g. simple write operation)
-          // and/or...
-          // ... the mtime changes (e.g. when a file is copied through the Windows Explorer*)
-          // * When the Windows Explorer copies a file, the size seems to be already set, and only 'mtime' changes
-          if (prevStats.size !== stats[i].size || prevStats.mtime.getTime() !== stats[i].mtime.getTime()) {
-            const msg = `File '${relPaths[i]}' is being written by another process`;
-            errors.push(new StacklessError(msg));
-          }
-        }
-
-        if (errors.length > 0) {
-          throw new AggregateError(errors);
-        }
-      });
+  for (const absPath of absPaths) {
+    promises.push(io.stat(absPath));
   }
+
+  const stats1 = new Map<string, fse.Stats>();
+
+  return Promise.all(promises)
+    .then((stats: fse.Stats[]) => {
+
+      for (let i = 0; i < relPaths.length; ++i) {
+        stats1.set(relPaths[i], stats[i]);
+      }
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 500);
+      });
+    }).then(() => {
+      const promises: Promise<fse.Stats>[] = [];
+
+      for (const absPath of absPaths) {
+        promises.push(io.stat(absPath));
+      }
+
+      return Promise.all(promises);
+    })
+    .then((stats: fse.Stats[]) => {
+
+      const errors: Error[] = [];
+
+      for (let i = 0; i < relPaths.length; ++i) {
+        const prevStats = stats1.get(relPaths[i]);
+        // When a file is being written by another process, either...
+        // ... the size changes through time (e.g. simple write operation)
+        // and/or...
+        // ... the mtime changes (e.g. when a file is copied through the Windows Explorer*)
+        // * When the Windows Explorer copies a file, the size seems to be already set, and only 'mtime' changes
+        if (prevStats && (prevStats.size !== stats[i].size || prevStats.mtime.getTime() !== stats[i].mtime.getTime())) {
+          const msg = `File '${relPaths[i]}' is being written by another process`;
+          errors.push(new StacklessError(msg));
+        }
+      }
+
+      if (errors.length > 0) {
+        throw new AggregateError(errors);
+      }
+    });
+}
+
+export namespace win32 {
 
   /**
    * Check if the passed files are open by any other process.
@@ -638,7 +632,7 @@ export class IoContext {
           switch (testIf) {
             case TEST_IF.FILE_CAN_BE_READ_FROM:
               // check if files are written by another process
-              return win32.checkReadAccess(absPaths, relPaths);
+              return checkReadAccess(absPaths, relPaths);
             case TEST_IF.FILE_CAN_BE_WRITTEN_TO:
             default:
               // Check if files are touched by any other process.
@@ -654,42 +648,54 @@ export class IoContext {
         });
     }
 
-    function checkUnixLike(relPaths): Promise<void> {
+    function checkUnixLike(relPaths: string[]): Promise<void> {
       const absPaths = relPaths.map((p: string) => join(dir, p));
+      const checkIfFilesAreReallyBeingWritten = new Map<string, string>();
+
       return checkAccess(absPaths)
-        .then(() => {
-          const promises = [];
-
-          for (const absPath of absPaths) {
-            promises.push(io.stat(absPath));
-          }
-
-          return Promise.all(promises);
-        })
         .then(() => {
           return unix.whichFilesInDirAreOpen(dir);
         })
         .then((fileHandles: Map<string, unix.FileHandle[]>) => {
-          const errors: Error[] = [];
 
-          for (const relPath of relPaths) {
-            const fhs: unix.FileHandle[] = fileHandles.get(relPath);
+          const zip = (a, b) => a.map((k, i) => [k, b[i]]);
+
+          const errors: Error[] = [];
+          for (const [absPath, relPath] of zip(absPaths, relPaths)) {
+            const fhs: unix.FileHandle[] | undefined = fileHandles.get(relPath);
             if (fhs) {
               for (const fh of fhs) {
-                if (fh.lockType === unix.LOCKTYPE.READ_WRITE_LOCK_FILE
-                    || fh.lockType === unix.LOCKTYPE.WRITE_LOCK_FILE
-                    || fh.lockType === unix.LOCKTYPE.WRITE_LOCK_FILE_PART) {
-                  const msg = `File '${relPath}' is being written by ${fh.processname ?? 'another process'}`;
-                  errors.push(new StacklessError(msg));
+                switch (fh.lockType) {
+                  case unix.LOCKTYPE.READ_WRITE_LOCK_FILE: {
+                    // Some applications like InDesign keep a read+write handle on the file
+                    // that is opened. That means, we can't really tell if the file is
+                    // actually being written. In that case, we resort to the approach that
+                    // we use on Windows to determine if the file is really being written.
+                    checkIfFilesAreReallyBeingWritten.set(absPath, relPath);
+                    break;
+                  }
+                  case unix.LOCKTYPE.WRITE_LOCK_FILE:
+                  case unix.LOCKTYPE.WRITE_LOCK_FILE_PART: {
+                    const msg = `File '${relPath}' is being written by ${fh.processname ?? 'another process'}`;
+                    errors.push(new StacklessError(msg));
+                    break;
+                  }
                 }
               }
             }
           }
-
           if (errors.length > 0) {
             throw new AggregateError(errors);
           }
-        });
+        })
+        .then(() => {
+          const absPaths: string[] = Array.from(checkIfFilesAreReallyBeingWritten.keys());
+          const relPaths: string[] = Array.from(checkIfFilesAreReallyBeingWritten.values());
+
+          return checkReadAccess(absPaths, relPaths);
+        })
+        .then(() => {
+        })
     }
 
     switch (process.platform) {

--- a/test/1.sys.test.ts
+++ b/test/1.sys.test.ts
@@ -932,8 +932,92 @@ async function performReadLockCheckTest(t, fileCount: number) {
   }
 }
 
+/**
+ * Create read/write file handles and check if only the files that are actively written to are being
+ * reported. On Linux and MacOS files that have a write AND read lock are checked differently than
+ * files that have a read or write lock. For more information see unix.LOCKTYPE.READ_WRITE_LOCK_FILE in io_context.ts.
+ * @param idleReadFile        Number of files to open in read+write mode but ARE NOT written to.
+ * @param activeWriteFile     Number of files to open in read+write mode but are written to.
+ */
+async function performReadWriteLockCheckTest(t, idleCnt: number, activeCnt: number): Promise<void> {
+  t.plan(activeCnt === 0 ? 1 : activeCnt + 1);  // there is one test below that checks that activeCnt === reported error messages
+
+  const tmp = join(process.cwd(), 'tmp');
+  fse.ensureDirSync(tmp);
+
+  const absDir = fse.mkdtempSync(join(tmp, 'snowtrack-'));
+
+  const fileHandles = new Map<string, number>();
+  const activeHandles = new Set<number>();
+
+  for (let i = 0; i < idleCnt; ++i) {
+    const readFileHandleFile = `idle-${i}.txt`;
+    const absPath = join(absDir, readFileHandleFile);
+    fse.ensureFileSync(absPath);
+    fileHandles.set(readFileHandleFile, fse.openSync(absPath, 'w+'));
+  }
+
+  for (let i = 0; i < activeCnt; ++i) {
+    const readFileHandleFile = `active-${i}.txt`;
+    const absPath = join(absDir, readFileHandleFile);
+    fse.ensureFileSync(absPath);
+    const fh = fse.openSync(absPath, 'w+');
+    fileHandles.set(readFileHandleFile, fh);
+    activeHandles.add(fh);
+  }
+
+  let stop = false;
+
+  function parallelWrite(): void {
+    activeHandles.forEach((fh: number) => {
+      fse.writeFile(fh, '123456789abcdefghijklmnopqrstuvwxyz\n');
+    });
+
+    setTimeout(() => {
+      if (stop) {
+        t.log('Stop parallel writes');
+      } else {
+        parallelWrite();
+      }
+    });
+  }
+
+  parallelWrite();
+
+  await sleep(500); // just to ensure on GitHub runners that all files were written to
+
+  const ioContext = new IoContext();
+  try {
+    await ioContext.performFileAccessCheck(absDir, Array.from(fileHandles.keys()), TEST_IF.FILE_CAN_BE_READ_FROM);
+    t.log('Ensure that only the active file handles are reported as being written');
+    if (idleCnt + activeCnt === 0) {
+      t.true(true); // to satisfy t.plan
+    }
+  } catch (error) {
+    if (error instanceof AggregateError) {
+      const errorMessages: string[] = error.errors.map((e) => e.message);
+      // only the active file handles must be reported as being written
+      t.log(`Expected ${activeCnt} files as being written, and reported ${errorMessages.length}`);
+      t.is(activeCnt, errorMessages.length);
+
+      for (let i = 0; i < errorMessages.length; ++i) {
+        t.is(`File 'active-${i}.txt' is being written by another process`, errorMessages[i]);
+      }
+    } else {
+      // any other error than AggregateError is unexpected
+      throw error;
+    }
+  }
+
+  stop = true;
+
+  for (const handle of Array.from(fileHandles.values())) {
+    fse.closeSync(handle);
+  }
+}
+
 if (process.platform === 'win32') {
-  test('performFileAccessCheck (read/write) / 0 file', async (t) => {
+  test('performFileAccessCheck (read/write) / 0 file [Win only]', async (t) => {
     try {
       await performReadLockCheckTest(t, 0);
     } catch (error) {
@@ -941,7 +1025,7 @@ if (process.platform === 'win32') {
     }
   });
 
-  test('performFileAccessCheck (read/write) / 1 file', async (t) => {
+  test('performFileAccessCheck (read/write) / 1 file [Win only]', async (t) => {
     try {
       await performReadLockCheckTest(t, 1);
     } catch (error) {
@@ -949,7 +1033,7 @@ if (process.platform === 'win32') {
     }
   });
 
-  test('performFileAccessCheck (read/write) / 100 file', async (t) => {
+  test('performFileAccessCheck (read/write) / 100 file [Win only]', async (t) => {
     try {
       await performReadLockCheckTest(t, 100);
     } catch (error) {
@@ -957,7 +1041,7 @@ if (process.platform === 'win32') {
     }
   });
 
-  test('performFileAccessCheck (read/write) / 1000 file', async (t) => {
+  test('performFileAccessCheck (read/write) / 1000 file [Win only]', async (t) => {
     try {
       await performReadLockCheckTest(t, 1000);
     } catch (error) {
@@ -965,9 +1049,18 @@ if (process.platform === 'win32') {
     }
   });
 
-  test('performFileAccessCheck (read/write) / 10000 file', async (t) => {
+  test('performFileAccessCheck (read/write) / 10000 file [Win only]', async (t) => {
     try {
       await performReadLockCheckTest(t, 10000);
+    } catch (error) {
+      t.fail(error.message);
+    }
+  });
+} else {
+  test('performReadWriteAccessCheck / 6 w+ files where 3 files are being written [macOS/Linux]', async (t) => {
+    try {
+      // On Linux and macOS we want to test for read+write handles
+      await performReadWriteLockCheckTest(t, 3, 3);
     } catch (error) {
       t.fail(error.message);
     }

--- a/test/3.repo.open.ts
+++ b/test/3.repo.open.ts
@@ -123,7 +123,7 @@ test('repo open-repo-workdir-commondir-collision-test', async (t) => {
   t.is(error3.message, 'workdir already exists');
 });
 
-test.only('repo open-repo ignore temp files', async (t) => {
+test('repo open-repo ignore temp files', async (t) => {
   // this unit-tests ensures that temp files in 'refs' or 'versions' are ignored upon opening a repo
   let repo: Repository;
 


### PR DESCRIPTION
On MacOS and Linux we determine if files are opened in read, write or read+write mode before they are copied to the index. Some applications (like InDesign) open their active documents in read+write mode. Before this fix, we threw an error and reported that the file is being written, which might not be the case overall.

This PR distinguishes if a file is in read, write or read+write mode. Every file that is opened in write+read mode is now tested if it is really being written by falling back to the same approach we use on Windows.