### PR TITLE
Use npm run ci-all to build SnowFS

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Upgrade node-gyp
         shell: powershell
         run: |
-              npm install --global node-gyp@9
+              npm ci --global node-gyp@9
               npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
     
-      - run: npm install
+      - run: npm ci
       - run: npm run benchmark
 
   macos-benchmark:
@@ -48,10 +48,10 @@ jobs:
 
       - name: Upgrade node-gyp
         run: |
-              npm install --global node-gyp@9
+              npm ci --global node-gyp@9
               npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
 
-      - run: npm install
+      - run: npm ci
       - run: npm run benchmark
 
 
@@ -70,10 +70,10 @@ jobs:
 
       - name: Upgrade node-gyp
         run: |
-              npm install --global node-gyp@9
+              npm ci --global node-gyp@9
               npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
 
-      - run: npm install
+      - run: npm ci
       - run: npm run ava
 
       - name: Coveralls GitHub Action
@@ -118,10 +118,10 @@ jobs:
 
       - name: Upgrade node-gyp
         run: |
-              npm install --global node-gyp@9
+              npm ci --global node-gyp@9
               npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
 
-      - run: npm install
+      - run: npm ci
       - run: npm run ava
 
       - name: Coveralls GitHub Action
@@ -167,10 +167,10 @@ jobs:
       - name: Upgrade node-gyp
         shell: powershell
         run: |
-              npm install --global node-gyp@9
+              npm ci --global node-gyp@9
               npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
 
-      - run: npm install
+      - run: npm ci
       - run: npm run ava
 
       - name: Coveralls GitHub Action

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Upgrade node-gyp
         shell: powershell
         run: |
-              npm ci --global node-gyp@9
+              npm install --global node-gyp@9
               npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
     
       - run: npm ci
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upgrade node-gyp
         run: |
-              npm ci --global node-gyp@9
+              npm install --global node-gyp@9
               npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
 
       - run: npm ci
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upgrade node-gyp
         run: |
-              npm ci --global node-gyp@9
+              npm install --global node-gyp@9
               npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
 
       - run: npm ci
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upgrade node-gyp
         run: |
-              npm ci --global node-gyp@9
+              npm install --global node-gyp@9
               npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
 
       - run: npm ci
@@ -167,7 +167,7 @@ jobs:
       - name: Upgrade node-gyp
         shell: powershell
         run: |
-              npm ci --global node-gyp@9
+              npm install --global node-gyp@9
               npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
 
       - run: npm ci


### PR DESCRIPTION
Use `npm ci` instead of `npm install` for the build pipeline.

# npm ci

See https://docs.npmjs.com/cli/v8/commands/npm-ci

> This command is similar to [npm install](https://docs.npmjs.com/cli/v8/commands/npm-install), except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies.