### PR TITLE
:broom: Rename 'alpha' to 'beta' in download button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SnowFS - a fast, scalable version control file storage for graphic files
 
-[![release](https://img.shields.io/badge/Download%20CLI%20Alpha-0.9.2-orange)](https://github.com/Snowtrack/SnowFS/releases/tag/v0.9.1)
+[![release](https://img.shields.io/badge/Download%20CLI%20Beta-0.9.2-orange)](https://github.com/Snowtrack/SnowFS/releases/tag/v0.9.1)
 [![Coverage Status](https://coveralls.io/repos/github/Snowtrack/SnowFS/badge.svg)](https://coveralls.io/github/Snowtrack/SnowFS)
 [![Build and Test](https://github.com/Snowtrack/SnowFS/workflows/Build%20and%20Test/badge.svg)](https://github.com/snowtrack/SnowFS/actions)
 [![MIT Licence](https://badges.frapsoft.com/os/mit/mit.png?v=102)](https://opensource.org/licenses/mit-license.php)
@@ -156,7 +156,7 @@ main();
 
 The CLI of `SnowFS` offers some basic functionality and is subject to enhancements. See [Report #90](https://github.com/Snowtrack/SnowFS/issues/90)
 
-[![release](https://img.shields.io/badge/Download%20CLI%20Alpha-0.9.2-orange)](https://github.com/Snowtrack/SnowFS/releases/tag/v0.9.2)
+[![release](https://img.shields.io/badge/Download%20CLI%20Beta-0.9.2-orange)](https://github.com/Snowtrack/SnowFS/releases/tag/v0.9.2)
 
 ```
 $ snow init foo


### PR DESCRIPTION
The download button in the `README.md` still used the Alpha label. Update to `beta` for https://github.com/snowtrack/snowfs/releases/tag/v0.9.2