### PR TITLE
Fix benchmark tests

### DIFF
--- a/benchmark/snowfs-vs-git.ts
+++ b/benchmark/snowfs-vs-git.ts
@@ -202,6 +202,7 @@ export async function startBenchmark(textureFilesize: number = BENCHMARK_FILE_SI
       playground = os.tmpdir();
     }
 
+    // Test if we can create directories in the playground
     const tmp: string = join(playground, 'benchmark-xyz-test');
     try {
       fse.mkdirpSync(tmp);

--- a/benchmark/snowfs-vs-git.ts
+++ b/benchmark/snowfs-vs-git.ts
@@ -100,7 +100,9 @@ async function createFile(dst: string, size: number, t = console) {
 }
 
 async function gitAddTexture(repoPath: string, textureFilesize: number = BENCHMARK_FILE_SIZE, t = console): Promise<number> {
-  fse.rmdirSync(repoPath, { recursive: true });
+  if (fse.pathExistsSync(repoPath)) {
+    fse.rmdirSync(repoPath, { recursive: true });
+  }
 
   t.log(`Create Git(+LFS) Repository at: ${repoPath}`);
   await exec('git', ['init', basename(repoPath)], t, { cwd: dirname(repoPath) });

--- a/benchmark/snowfs-vs-git.ts
+++ b/benchmark/snowfs-vs-git.ts
@@ -9,7 +9,7 @@ import { Repository, RESET } from '../src/repository';
 // eslint-disable-next-line import/no-extraneous-dependencies
 const chalk = require('chalk');
 
-const BENCHMARK_FILE_SIZE = 4000000000;
+const BENCHMARK_FILE_SIZE = process.platform === 'win32' ? 1000000000 : 4000000000;
 
 async function input(question: string): Promise<string> {
   const rl = readline.createInterface({

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "url": "https://github.com/snowtrack/snowfs.git"
   },
   "engines": {
-    "node": "14.17.6"
+    "node": ">=14.17.6"
   },
   "dependencies": {
     "@supercharge/promise-pool": "^2.1.0",


### PR DESCRIPTION
This PR fixes the benchmark test for GitHub runner. The test size is also reduced to 1GB for Windows since they run easily out of memory.