### PR TITLE
Add changed file information to snow log

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 - Sean Mitchell https://github.com/dskvr 
 - Nicola Dardanis <https://github.com/nicdard>
 - KOGA Mitsuhiro <https://github.com/shiena>
+- belkarx <belkarx0@outlook.com>

--- a/main.ts
+++ b/main.ts
@@ -520,7 +520,6 @@ program
     if (opts.noColor) {
       chalk.level = 0;
     }
-    
     try {
       const repo = await Repository.open(normalize(process.cwd()));
 
@@ -572,7 +571,6 @@ program
                                           : undefined,
             };
           }
-
           if (value instanceof Reference) {
             return {
               name: value.getName(),

--- a/test/10.cli.ts
+++ b/test/10.cli.ts
@@ -242,8 +242,6 @@ test('snow checkout', async (t) => {
   t.false(fse.pathExistsSync(join(snowWorkdir, 'abc1.txt')));
 });
 
-
-
 test('snow branch foo-branch', async (t) => {
   t.timeout(180000);
 
@@ -392,7 +390,6 @@ test('snow add *', async (t) => {
 /**
  * This test ensures that foo.txt is not added to the staging area because cwd is the subdirectory
  */
-
 test('snow add foo.txt', async (t) => {
   const snow: string = getSnowexec();
   const snowWorkdir = generateUniqueTmpDirName();

--- a/test/7.repo.diff.ts
+++ b/test/7.repo.diff.ts
@@ -50,7 +50,7 @@ test('Diff.basic', async (t) => {
   // Commit 3: create a file fooB.txt
   const commit3: Commit = await writeFileAndCommit(repo, 'fooB.txt', 'fooB-content');
 
-  // Commit 4: create a file fooB.txt
+  // Commit 4: delete a file fooB.txt
   const commit4: Commit = await deleteFileAndCommit(repo, 'fooB.txt', 'delete fooB.txt');
 
   const test0 = () => {


### PR DESCRIPTION
## Description

Adds info on whether a file has been added/modified in `snow log` via a `--changed-information` flag

The output is in JSON, and a `status` field is added to each TreeFile output in each commit with "added" or "modified" (creating a "deleted" flag proved to be a bit ambiguous in definition and I believe required changes to the underlying commit diffing function [I may be wrong here and just not familiar enough with TS/this codebase to make it work, but either way it didn't happen]).

Fixes #144  

## Checks

- [ x ] I added my name to the contributor list in **CONTRIBUTORS.md**
- [ x ] I understand that my work will be licensed under the given license of `SnowFS`
- [ x ] I am the original author, or I have authorization to submit this work.


## Type of change

Please delete options that are not relevant.
- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] This change requires a documentation update